### PR TITLE
Issue 14 - Add Geolocation support for user's current location

### DIFF
--- a/OTPKit/Features/OriginDestination/Components/AddFavoriteLocationsSheet.swift
+++ b/OTPKit/Features/OriginDestination/Components/AddFavoriteLocationsSheet.swift
@@ -16,6 +16,9 @@ public struct AddFavoriteLocationsSheet: View {
     @EnvironmentObject private var sheetEnvironment: OriginDestinationSheetEnvironment
 
     @State private var search = ""
+    private let userLocation = UserLocationServices.shared.currentLocation
+
+    @FocusState private var isSearchActive: Bool
 
     private var filteredCompletions: [Location] {
         let favorites = sheetEnvironment.favoriteLocations
@@ -48,6 +51,7 @@ public struct AddFavoriteLocationsSheet: View {
                 Image(systemName: "magnifyingglass")
                 TextField("Search for a place", text: $search)
                     .autocorrectionDisabled()
+                    .focused($isSearchActive)
             }
             .padding(.vertical, 8)
             .padding(.horizontal, 12)
@@ -56,6 +60,31 @@ public struct AddFavoriteLocationsSheet: View {
             .padding(.horizontal, 16)
 
             List {
+                if search.isEmpty, let userLocation = userLocation {
+                    Button(action: {
+                        switch UserDefaultsServices.shared.saveFavoriteLocationData(data: userLocation) {
+                        case .success:
+                            sheetEnvironment.refreshFavoriteLocations()
+                            dismiss()
+                        case let .failure(error):
+                            print(error)
+                        }
+                    }, label: {
+                        HStack {
+                            VStack(alignment: .leading) {
+                                Text(userLocation.title)
+                                    .font(.headline)
+                                Text(userLocation.subTitle)
+                            }.foregroundStyle(Color.black)
+
+                            Spacer()
+
+                            Image(systemName: "plus")
+                        }
+
+                    })
+                }
+
                 ForEach(filteredCompletions) { location in
                     Button(action: {
                         switch UserDefaultsServices.shared.saveFavoriteLocationData(data: location) {

--- a/OTPKit/Features/OriginDestination/OriginDestinationView.swift
+++ b/OTPKit/Features/OriginDestination/OriginDestinationView.swift
@@ -16,7 +16,7 @@ public struct OriginDestinationView: View {
 
     // Public Initializer
     public init() {}
-    
+
     public var body: some View {
         VStack {
             List {

--- a/OTPKit/Services/UserLocationServices.swift
+++ b/OTPKit/Services/UserLocationServices.swift
@@ -8,6 +8,7 @@
 import Foundation
 import MapKit
 
+/// `UserLocationServices` responsible for asking permission, and manage current users location
 public final class UserLocationServices: NSObject, ObservableObject, CLLocationManagerDelegate {
     @Published var currentLocation: Location?
 
@@ -15,15 +16,15 @@ public final class UserLocationServices: NSObject, ObservableObject, CLLocationM
 
     var locationManager: CLLocationManager = .init()
 
-    public init(currentLocation: Location? = nil) {
-        self.currentLocation = currentLocation
+    override private init() {
+        super.init()
+        locationManager.delegate = self
+        locationManager.desiredAccuracy = kCLLocationAccuracyBest
     }
 
     public func checkIfLocationServicesIsEnabled() {
         DispatchQueue.global().async {
             if CLLocationManager.locationServicesEnabled() {
-                self.locationManager.delegate = self
-                self.locationManager.desiredAccuracy = kCLLocationAccuracyBest
                 self.checkLocationAuthorization()
             }
         }
@@ -53,5 +54,9 @@ public final class UserLocationServices: NSObject, ObservableObject, CLLocationM
                 longitude: location.coordinate.longitude
             )
         }
+    }
+
+    public func locationManagerDidChangeAuthorization(_: CLLocationManager) {
+        checkLocationAuthorization()
     }
 }

--- a/OTPKit/Services/UserLocationServices.swift
+++ b/OTPKit/Services/UserLocationServices.swift
@@ -1,0 +1,57 @@
+//
+//  UserLocationServices.swift
+//  OTPKit
+//
+//  Created by Hilmy Veradin on 06/07/24.
+//
+
+import Foundation
+import MapKit
+
+public final class UserLocationServices: NSObject, ObservableObject, CLLocationManagerDelegate {
+    @Published var currentLocation: Location?
+
+    public static let shared = UserLocationServices()
+
+    var locationManager: CLLocationManager = .init()
+
+    public init(currentLocation: Location? = nil) {
+        self.currentLocation = currentLocation
+    }
+
+    public func checkIfLocationServicesIsEnabled() {
+        DispatchQueue.global().async {
+            if CLLocationManager.locationServicesEnabled() {
+                self.locationManager.delegate = self
+                self.locationManager.desiredAccuracy = kCLLocationAccuracyBest
+                self.checkLocationAuthorization()
+            }
+        }
+    }
+
+    private func checkLocationAuthorization() {
+        switch locationManager.authorizationStatus {
+        case .notDetermined:
+            locationManager.requestWhenInUseAuthorization()
+        case .restricted, .denied:
+            // Handle restricted or denied
+            break
+        case .authorizedAlways, .authorizedWhenInUse:
+            locationManager.startUpdatingLocation()
+        @unknown default:
+            break
+        }
+    }
+
+    public func locationManager(_: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        guard let location = locations.last else { return }
+        DispatchQueue.main.async {
+            self.currentLocation = Location(
+                title: "My Location",
+                subTitle: "Your current location",
+                latitude: location.coordinate.latitude,
+                longitude: location.coordinate.longitude
+            )
+        }
+    }
+}

--- a/OTPKitDemo/MapView.swift
+++ b/OTPKitDemo/MapView.swift
@@ -12,6 +12,8 @@ import SwiftUI
 public struct MapView: View {
     @StateObject private var sheetEnvironment = OriginDestinationSheetEnvironment()
 
+    @StateObject private var locationServices = UserLocationServices.shared
+
     static let mockCoordinate = CLLocationCoordinate2D(latitude: 51.507222, longitude: -0.1275)
     static let mockSpan = MKCoordinateSpan(latitudeDelta: 0.5, longitudeDelta: 0.5)
 
@@ -28,6 +30,9 @@ public struct MapView: View {
 
             OriginDestinationView()
                 .environmentObject(sheetEnvironment)
+        }
+        .onAppear {
+            locationServices.checkIfLocationServicesIsEnabled()
         }
     }
 }


### PR DESCRIPTION
# Add geolocation support for user's current location

## Related Issues
#14 

## Description
This PR related to issue #14. Within this PR, the changes included are:
1. If user opens the map, it will ask a permission to ask for a location
2. When search component in `add favorite location` and `search for location` is clicked, the user's location will appear
3. When users type in search component of add favorite location and search for location, the user's location will dissapear and replaced by searched locations

## Media
https://github.com/OneBusAway/otpkit/assets/74521244/b417b60f-069a-43b0-b476-7d56264b98d1

## Test Instructions

To test this PR, you can do the following:

1. Uninstall the OTPKitDemo app in your simulator
2. Re-run, set the simulator location. For example, [here](https://stackoverflow.com/questions/214416/set-the-location-in-iphone-simulator)
3. See if location permission is asked. Grant the permission
4. Open any origin or destination menu
5. Try to tap on search component. When it's focused or tapped, the row of "My Location" should appear
6. Try to type on the search component, "My Location" row should dissapear

## Additional Context

This PR is rebased from this PR #20. If you want to check for changes for this PR only, you should merge PR first
