### PR TITLE
Integration Groundwork

### DIFF
--- a/OTPKit/Features/MapExtension/MapMarkingView.swift
+++ b/OTPKit/Features/MapExtension/MapMarkingView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 public struct MapMarkingView: View {
-    @ObservedObject private var locationManagerService = TripPlannerService.shared
+    @EnvironmentObject private var locationManagerService: TripPlannerService
 
     public init() {}
     public var body: some View {
@@ -52,4 +52,5 @@ public struct MapMarkingView: View {
 
 #Preview {
     MapMarkingView()
+        .environmentObject(PreviewHelpers.buildTripPlannerService())
 }

--- a/OTPKit/Features/MapExtension/MapMarkingView.swift
+++ b/OTPKit/Features/MapExtension/MapMarkingView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 public struct MapMarkingView: View {
-    @EnvironmentObject private var locationManagerService: TripPlannerService
+    @EnvironmentObject private var tripPlanner: TripPlannerService
 
     public init() {}
     public var body: some View {
@@ -22,9 +22,9 @@ public struct MapMarkingView: View {
 
             HStack(spacing: 16) {
                 Button {
-                    locationManagerService.toggleMapMarkingMode(false)
-                    locationManagerService.selectAndRefreshCoordinate()
-                    locationManagerService.removeOriginDestinationData()
+                    tripPlanner.toggleMapMarkingMode(false)
+                    tripPlanner.selectAndRefreshCoordinate()
+                    tripPlanner.removeOriginDestinationData()
                 } label: {
                     Text("Cancel")
                         .padding(8)
@@ -33,9 +33,9 @@ public struct MapMarkingView: View {
                 .buttonStyle(.bordered)
 
                 Button {
-                    locationManagerService.toggleMapMarkingMode(false)
-                    locationManagerService.addOriginDestinationData()
-                    locationManagerService.selectAndRefreshCoordinate()
+                    tripPlanner.toggleMapMarkingMode(false)
+                    tripPlanner.addOriginDestinationData()
+                    tripPlanner.selectAndRefreshCoordinate()
                 } label: {
                     Text("Add Pin")
                         .padding(8)

--- a/OTPKit/Features/MapExtension/MapMarkingView.swift
+++ b/OTPKit/Features/MapExtension/MapMarkingView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 public struct MapMarkingView: View {
-    @ObservedObject private var locationManagerService = LocationManagerService.shared
+    @ObservedObject private var locationManagerService = TripPlannerService.shared
 
     public init() {}
     public var body: some View {

--- a/OTPKit/Features/OriginDestination/OriginDestinationView.swift
+++ b/OTPKit/Features/OriginDestination/OriginDestinationView.swift
@@ -12,7 +12,7 @@ import SwiftUI
 /// It consists a list of Origin and Destination along with the `MapKit`
 public struct OriginDestinationView: View {
     @EnvironmentObject private var sheetEnvironment: OriginDestinationSheetEnvironment
-    @ObservedObject private var locationManagerService = TripPlannerService.shared
+    @EnvironmentObject private var locationManagerService: TripPlannerService
     @State private var isSheetOpened = false
 
     // Public Initializer
@@ -63,4 +63,5 @@ public struct OriginDestinationView: View {
 
 #Preview {
     OriginDestinationView()
+        .environmentObject(PreviewHelpers.buildTripPlannerService())
 }

--- a/OTPKit/Features/OriginDestination/OriginDestinationView.swift
+++ b/OTPKit/Features/OriginDestination/OriginDestinationView.swift
@@ -12,7 +12,7 @@ import SwiftUI
 /// It consists a list of Origin and Destination along with the `MapKit`
 public struct OriginDestinationView: View {
     @EnvironmentObject private var sheetEnvironment: OriginDestinationSheetEnvironment
-    @ObservedObject private var locationManagerService = LocationManagerService.shared
+    @ObservedObject private var locationManagerService = TripPlannerService.shared
     @State private var isSheetOpened = false
 
     // Public Initializer

--- a/OTPKit/Features/OriginDestination/OriginDestinationView.swift
+++ b/OTPKit/Features/OriginDestination/OriginDestinationView.swift
@@ -12,7 +12,7 @@ import SwiftUI
 /// It consists a list of Origin and Destination along with the `MapKit`
 public struct OriginDestinationView: View {
     @EnvironmentObject private var sheetEnvironment: OriginDestinationSheetEnvironment
-    @EnvironmentObject private var locationManagerService: TripPlannerService
+    @EnvironmentObject private var tripPlanner: TripPlannerService
     @State private var isSheetOpened = false
 
     // Public Initializer
@@ -23,7 +23,7 @@ public struct OriginDestinationView: View {
             List {
                 Button(action: {
                     sheetEnvironment.isSheetOpened.toggle()
-                    locationManagerService.originDestinationState = .origin
+                    tripPlanner.originDestinationState = .origin
                 }, label: {
                     HStack(spacing: 16) {
                         Image(systemName: "paperplane.fill")
@@ -32,14 +32,14 @@ public struct OriginDestinationView: View {
                                     .fill(Color.green)
                                     .frame(width: 30, height: 30)
                             )
-                        Text(locationManagerService.originName)
+                        Text(tripPlanner.originName)
                     }
                 })
                 .foregroundStyle(.foreground)
 
                 Button(action: {
                     sheetEnvironment.isSheetOpened.toggle()
-                    locationManagerService.originDestinationState = .destination
+                    tripPlanner.originDestinationState = .destination
                 }, label: {
                     HStack(spacing: 16) {
                         Image(systemName: "mappin")
@@ -48,7 +48,7 @@ public struct OriginDestinationView: View {
                                     .fill(Color.green)
                                     .frame(width: 30, height: 30)
                             )
-                        Text(locationManagerService.destinationName)
+                        Text(tripPlanner.destinationName)
                     }
                 })
                 .foregroundStyle(.foreground)

--- a/OTPKit/Features/OriginDestination/Sheets/AddFavoriteLocationsSheet.swift
+++ b/OTPKit/Features/OriginDestination/Sheets/AddFavoriteLocationsSheet.swift
@@ -13,7 +13,7 @@ public struct AddFavoriteLocationsSheet: View {
     @Environment(\.dismiss) var dismiss
     @EnvironmentObject private var sheetEnvironment: OriginDestinationSheetEnvironment
 
-    @ObservedObject private var locationManagerService = LocationManagerService.shared
+    @ObservedObject private var locationManagerService = TripPlannerService.shared
 
     @State private var search = ""
 

--- a/OTPKit/Features/OriginDestination/Sheets/AddFavoriteLocationsSheet.swift
+++ b/OTPKit/Features/OriginDestination/Sheets/AddFavoriteLocationsSheet.swift
@@ -12,7 +12,7 @@ import SwiftUI
 public struct AddFavoriteLocationsSheet: View {
     @Environment(\.dismiss) var dismiss
     @EnvironmentObject private var sheetEnvironment: OriginDestinationSheetEnvironment
-    @EnvironmentObject private var locationManagerService: TripPlannerService
+    @EnvironmentObject private var tripPlanner: TripPlannerService
 
     @State private var search = ""
 
@@ -20,7 +20,7 @@ public struct AddFavoriteLocationsSheet: View {
 
     private var filteredCompletions: [Location] {
         let favorites = sheetEnvironment.favoriteLocations
-        return locationManagerService.completions.filter { completion in
+        return tripPlanner.completions.filter { completion in
             !favorites.contains { favorite in
                 favorite.title == completion.title &&
                     favorite.subTitle == completion.subTitle
@@ -29,7 +29,7 @@ public struct AddFavoriteLocationsSheet: View {
     }
 
     private func currentUserSection() -> some View {
-        if search.isEmpty, let userLocation = locationManagerService.currentLocation {
+        if search.isEmpty, let userLocation = tripPlanner.currentLocation {
             AnyView(
                 Button(action: {
                     switch UserDefaultsServices.shared.saveFavoriteLocationData(data: userLocation) {
@@ -100,7 +100,7 @@ public struct AddFavoriteLocationsSheet: View {
                 searchedResultsSection()
             }
             .onChange(of: search) { _, searchValue in
-                locationManagerService.updateQuery(queryFragment: searchValue)
+                tripPlanner.updateQuery(queryFragment: searchValue)
             }
         }
     }

--- a/OTPKit/Features/OriginDestination/Sheets/AddFavoriteLocationsSheet.swift
+++ b/OTPKit/Features/OriginDestination/Sheets/AddFavoriteLocationsSheet.swift
@@ -12,8 +12,7 @@ import SwiftUI
 public struct AddFavoriteLocationsSheet: View {
     @Environment(\.dismiss) var dismiss
     @EnvironmentObject private var sheetEnvironment: OriginDestinationSheetEnvironment
-
-    @ObservedObject private var locationManagerService = TripPlannerService.shared
+    @EnvironmentObject private var locationManagerService: TripPlannerService
 
     @State private var search = ""
 
@@ -109,4 +108,5 @@ public struct AddFavoriteLocationsSheet: View {
 
 #Preview {
     AddFavoriteLocationsSheet()
+        .environmentObject(PreviewHelpers.buildTripPlannerService())
 }

--- a/OTPKit/Features/OriginDestination/Sheets/MoreFavoriteLocationsSheet.swift
+++ b/OTPKit/Features/OriginDestination/Sheets/MoreFavoriteLocationsSheet.swift
@@ -11,7 +11,7 @@ import SwiftUI
 public struct MoreFavoriteLocationsSheet: View {
     @Environment(\.dismiss) private var dismiss
     @EnvironmentObject private var sheetEnvironment: OriginDestinationSheetEnvironment
-    @EnvironmentObject private var locationManagerService: TripPlannerService
+    @EnvironmentObject private var tripPlanner: TripPlannerService
 
     @State private var isDetailSheetOpened = false
 

--- a/OTPKit/Features/OriginDestination/Sheets/MoreFavoriteLocationsSheet.swift
+++ b/OTPKit/Features/OriginDestination/Sheets/MoreFavoriteLocationsSheet.swift
@@ -12,7 +12,7 @@ public struct MoreFavoriteLocationsSheet: View {
     @Environment(\.dismiss) private var dismiss
 
     @EnvironmentObject private var sheetEnvironment: OriginDestinationSheetEnvironment
-    @ObservedObject private var locationManagerService = LocationManagerService.shared
+    @ObservedObject private var locationManagerService = TripPlannerService.shared
 
     @State private var isDetailSheetOpened = false
 

--- a/OTPKit/Features/OriginDestination/Sheets/MoreFavoriteLocationsSheet.swift
+++ b/OTPKit/Features/OriginDestination/Sheets/MoreFavoriteLocationsSheet.swift
@@ -10,9 +10,8 @@ import SwiftUI
 /// Show all the lists of favorite locations
 public struct MoreFavoriteLocationsSheet: View {
     @Environment(\.dismiss) private var dismiss
-
     @EnvironmentObject private var sheetEnvironment: OriginDestinationSheetEnvironment
-    @ObservedObject private var locationManagerService = TripPlannerService.shared
+    @EnvironmentObject private var locationManagerService: TripPlannerService
 
     @State private var isDetailSheetOpened = false
 
@@ -45,4 +44,5 @@ public struct MoreFavoriteLocationsSheet: View {
 
 #Preview {
     MoreFavoriteLocationsSheet()
+        .environmentObject(PreviewHelpers.buildTripPlannerService())
 }

--- a/OTPKit/Features/OriginDestination/Sheets/OriginDestinationSheetView.swift
+++ b/OTPKit/Features/OriginDestination/Sheets/OriginDestinationSheetView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 public struct OriginDestinationSheetView: View {
     @Environment(\.dismiss) var dismiss
     @EnvironmentObject var sheetEnvironment: OriginDestinationSheetEnvironment
-    @EnvironmentObject private var locationManagerService: TripPlannerService
+    @EnvironmentObject private var tripPlanner: TripPlannerService
 
     @State private var search: String = ""
 
@@ -71,8 +71,8 @@ public struct OriginDestinationSheetView: View {
                 HStack {
                     ForEach(sheetEnvironment.favoriteLocations, content: { location in
                         FavoriteView(title: location.title, imageName: "mappin", tapAction: {
-                            locationManagerService.appendMarker(location: location)
-                            locationManagerService.addOriginDestinationData()
+                            tripPlanner.appendMarker(location: location)
+                            tripPlanner.addOriginDestinationData()
                             dismiss()
                         }, longTapAction: {
                             isShowFavoriteConfirmationDialog = true
@@ -101,8 +101,8 @@ public struct OriginDestinationSheetView: View {
             Section(content: {
                 ForEach(Array(sheetEnvironment.recentLocations.prefix(5)), content: { location in
                     Button {
-                        locationManagerService.appendMarker(location: location)
-                        locationManagerService.addOriginDestinationData()
+                        tripPlanner.appendMarker(location: location)
+                        tripPlanner.addOriginDestinationData()
                         dismiss()
                     } label: {
                         VStack(alignment: .leading) {
@@ -123,10 +123,10 @@ public struct OriginDestinationSheetView: View {
 
     private func searchResultsSection() -> some View {
         Group {
-            ForEach(locationManagerService.completions) { location in
+            ForEach(tripPlanner.completions) { location in
                 Button(action: {
-                    locationManagerService.appendMarker(location: location)
-                    locationManagerService.addOriginDestinationData()
+                    tripPlanner.appendMarker(location: location)
+                    tripPlanner.addOriginDestinationData()
                     switch UserDefaultsServices.shared.saveRecentLocations(data: location) {
                     case .success:
                         dismiss()
@@ -148,10 +148,10 @@ public struct OriginDestinationSheetView: View {
 
     private func currentUserSection() -> some View {
         Group {
-            if let userLocation = locationManagerService.currentLocation {
+            if let userLocation = tripPlanner.currentLocation {
                 Button(action: {
-                    locationManagerService.appendMarker(location: userLocation)
-                    locationManagerService.addOriginDestinationData()
+                    tripPlanner.appendMarker(location: userLocation)
+                    tripPlanner.addOriginDestinationData()
                     switch UserDefaultsServices.shared.saveRecentLocations(data: userLocation) {
                     case .success:
                         dismiss()
@@ -175,7 +175,7 @@ public struct OriginDestinationSheetView: View {
 
     private func selectLocationBasedOnMap() -> some View {
         Button(action: {
-            locationManagerService.toggleMapMarkingMode(true)
+            tripPlanner.toggleMapMarkingMode(true)
             dismiss()
         }, label: {
             HStack {
@@ -208,7 +208,7 @@ public struct OriginDestinationSheetView: View {
                 }
             }
             .onChange(of: search) { _, searchValue in
-                locationManagerService.updateQuery(queryFragment: searchValue)
+                tripPlanner.updateQuery(queryFragment: searchValue)
             }
 
             Spacer()
@@ -222,11 +222,11 @@ public struct OriginDestinationSheetView: View {
             case .addFavoriteSheet:
                 AddFavoriteLocationsSheet()
                     .environmentObject(sheetEnvironment)
-                    .environmentObject(locationManagerService)
+                    .environmentObject(tripPlanner)
             case .moreFavoritesSheet:
                 MoreFavoriteLocationsSheet()
                     .environmentObject(sheetEnvironment)
-                    .environmentObject(locationManagerService)
+                    .environmentObject(tripPlanner)
             case .favoriteDetailsSheet:
                 FavoriteLocationDetailSheet()
                     .environmentObject(sheetEnvironment)

--- a/OTPKit/Features/OriginDestination/Sheets/OriginDestinationSheetView.swift
+++ b/OTPKit/Features/OriginDestination/Sheets/OriginDestinationSheetView.swift
@@ -10,8 +10,7 @@ import SwiftUI
 public struct OriginDestinationSheetView: View {
     @Environment(\.dismiss) var dismiss
     @EnvironmentObject var sheetEnvironment: OriginDestinationSheetEnvironment
-
-    @ObservedObject private var locationManagerService = TripPlannerService.shared
+    @EnvironmentObject private var locationManagerService: TripPlannerService
 
     @State private var search: String = ""
 
@@ -223,9 +222,11 @@ public struct OriginDestinationSheetView: View {
             case .addFavoriteSheet:
                 AddFavoriteLocationsSheet()
                     .environmentObject(sheetEnvironment)
+                    .environmentObject(locationManagerService)
             case .moreFavoritesSheet:
                 MoreFavoriteLocationsSheet()
                     .environmentObject(sheetEnvironment)
+                    .environmentObject(locationManagerService)
             case .favoriteDetailsSheet:
                 FavoriteLocationDetailSheet()
                     .environmentObject(sheetEnvironment)
@@ -248,4 +249,5 @@ public struct OriginDestinationSheetView: View {
 #Preview {
     OriginDestinationSheetView()
         .environmentObject(OriginDestinationSheetEnvironment())
+        .environmentObject(PreviewHelpers.buildTripPlannerService())
 }

--- a/OTPKit/Features/OriginDestination/Sheets/OriginDestinationSheetView.swift
+++ b/OTPKit/Features/OriginDestination/Sheets/OriginDestinationSheetView.swift
@@ -11,7 +11,7 @@ public struct OriginDestinationSheetView: View {
     @Environment(\.dismiss) var dismiss
     @EnvironmentObject var sheetEnvironment: OriginDestinationSheetEnvironment
 
-    @ObservedObject private var locationManagerService = LocationManagerService.shared
+    @ObservedObject private var locationManagerService = TripPlannerService.shared
 
     @State private var search: String = ""
 

--- a/OTPKit/Features/TripPlanner/Direction/DirectionSheetView.swift
+++ b/OTPKit/Features/TripPlanner/Direction/DirectionSheetView.swift
@@ -2,7 +2,7 @@ import MapKit
 import SwiftUI
 
 public struct DirectionSheetView: View {
-    @ObservedObject private var locationManagerService = LocationManagerService.shared
+    @ObservedObject private var locationManagerService = TripPlannerService.shared
     @Environment(\.dismiss) private var dismiss
     @Binding var sheetDetent: PresentationDetent
     @State private var scrollToItem: String?

--- a/OTPKit/Features/TripPlanner/Direction/DirectionSheetView.swift
+++ b/OTPKit/Features/TripPlanner/Direction/DirectionSheetView.swift
@@ -2,7 +2,7 @@ import MapKit
 import SwiftUI
 
 public struct DirectionSheetView: View {
-    @EnvironmentObject private var locationManagerService: TripPlannerService
+    @EnvironmentObject private var tripPlanner: TripPlannerService
     @Environment(\.dismiss) private var dismiss
     @Binding var sheetDetent: PresentationDetent
     @State private var scrollToItem: String?
@@ -27,7 +27,7 @@ public struct DirectionSheetView: View {
     private func handleTap(coordinate: CLLocationCoordinate2D, itemId: String) {
         let placemark = MKPlacemark(coordinate: coordinate)
         let item = MKMapItem(placemark: placemark)
-        locationManagerService.changeMapCamera(item)
+        tripPlanner.changeMapCamera(item)
         scrollToItem = itemId
         sheetDetent = .fraction(0.2)
     }
@@ -36,15 +36,15 @@ public struct DirectionSheetView: View {
         ScrollViewReader { proxy in
             List {
                 Section {
-                    PageHeaderView(text: "\(locationManagerService.destinationName)") {
-                        locationManagerService.resetTripPlanner()
+                    PageHeaderView(text: "\(tripPlanner.destinationName)") {
+                        tripPlanner.resetTripPlanner()
                         dismiss()
                     }
                     .frame(height: 50)
                     .listRowInsets(EdgeInsets())
                 }
 
-                if let itinerary = locationManagerService.selectedItinerary {
+                if let itinerary = tripPlanner.selectedItinerary {
                     Section {
                         createOriginView(itinerary: itinerary)
                         createLegsView(itinerary: itinerary)
@@ -71,11 +71,11 @@ public struct DirectionSheetView: View {
     private func createOriginView(itinerary _: Itinerary) -> some View {
         DirectionLegOriginDestinationView(
             title: "Origin",
-            description: locationManagerService.originName
+            description: tripPlanner.originName
         )
         .id("item-0")
         .onTapGesture {
-            if let originCoordinate = locationManagerService.originCoordinate {
+            if let originCoordinate = tripPlanner.originCoordinate {
                 handleTap(coordinate: originCoordinate, itemId: "item-0")
             }
         }
@@ -95,11 +95,11 @@ public struct DirectionSheetView: View {
     private func createDestinationView(itinerary: Itinerary) -> some View {
         DirectionLegOriginDestinationView(
             title: "Destination",
-            description: locationManagerService.destinationName
+            description: tripPlanner.destinationName
         )
         .id("item-\(itinerary.legs.count + 1)")
         .onTapGesture {
-            if let destinationCoordinate = locationManagerService.destinationCoordinate {
+            if let destinationCoordinate = tripPlanner.destinationCoordinate {
                 handleTap(coordinate: destinationCoordinate, itemId: "item-\(itinerary.legs.count + 1)")
             }
         }

--- a/OTPKit/Features/TripPlanner/Direction/DirectionSheetView.swift
+++ b/OTPKit/Features/TripPlanner/Direction/DirectionSheetView.swift
@@ -2,7 +2,7 @@ import MapKit
 import SwiftUI
 
 public struct DirectionSheetView: View {
-    @ObservedObject private var locationManagerService = TripPlannerService.shared
+    @EnvironmentObject private var locationManagerService: TripPlannerService
     @Environment(\.dismiss) private var dismiss
     @Binding var sheetDetent: PresentationDetent
     @State private var scrollToItem: String?
@@ -108,4 +108,5 @@ public struct DirectionSheetView: View {
 
 #Preview {
     DirectionSheetView(sheetDetent: .constant(.fraction(0.2)))
+        .environmentObject(PreviewHelpers.buildTripPlannerService())
 }

--- a/OTPKit/Features/TripPlanner/SelectItenerary/TripPlannerSheetView.swift
+++ b/OTPKit/Features/TripPlanner/SelectItenerary/TripPlannerSheetView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 public struct TripPlannerSheetView: View {
-    @EnvironmentObject private var locationManagerService: TripPlannerService
+    @EnvironmentObject private var tripPlanner: TripPlannerService
     @Environment(\.dismiss) var dismiss
 
     public init() {}
@@ -28,11 +28,11 @@ public struct TripPlannerSheetView: View {
 
     public var body: some View {
         VStack {
-            if let itineraries = locationManagerService.planResponse?.plan?.itineraries {
+            if let itineraries = tripPlanner.planResponse?.plan?.itineraries {
                 List(itineraries, id: \.self) { itinerary in
                     Button(action: {
-                        locationManagerService.selectedItinerary = itinerary
-                        locationManagerService.planResponse = nil
+                        tripPlanner.selectedItinerary = itinerary
+                        tripPlanner.planResponse = nil
                         dismiss()
                     }, label: {
                         HStack(spacing: 20) {
@@ -60,9 +60,9 @@ public struct TripPlannerSheetView: View {
                             }
 
                             Button(action: {
-                                locationManagerService.selectedItinerary = itinerary
-                                locationManagerService.planResponse = nil
-                                locationManagerService.adjustOriginDestinationCamera()
+                                tripPlanner.selectedItinerary = itinerary
+                                tripPlanner.planResponse = nil
+                                tripPlanner.adjustOriginDestinationCamera()
                                 dismiss()
                             }, label: {
                                 Text("Preview")
@@ -82,7 +82,7 @@ public struct TripPlannerSheetView: View {
             }
 
             Button(action: {
-                locationManagerService.resetTripPlanner()
+                tripPlanner.resetTripPlanner()
                 dismiss()
             }, label: {
                 Text("Cancel")

--- a/OTPKit/Features/TripPlanner/SelectItenerary/TripPlannerSheetView.swift
+++ b/OTPKit/Features/TripPlanner/SelectItenerary/TripPlannerSheetView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 public struct TripPlannerSheetView: View {
-    @ObservedObject private var locationManagerService = TripPlannerService.shared
+    @EnvironmentObject private var locationManagerService: TripPlannerService
     @Environment(\.dismiss) var dismiss
 
     public init() {}
@@ -99,4 +99,5 @@ public struct TripPlannerSheetView: View {
 
 #Preview {
     TripPlannerSheetView()
+        .environmentObject(PreviewHelpers.buildTripPlannerService())
 }

--- a/OTPKit/Features/TripPlanner/SelectItenerary/TripPlannerSheetView.swift
+++ b/OTPKit/Features/TripPlanner/SelectItenerary/TripPlannerSheetView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 public struct TripPlannerSheetView: View {
-    @ObservedObject private var locationManagerService = LocationManagerService.shared
+    @ObservedObject private var locationManagerService = TripPlannerService.shared
     @Environment(\.dismiss) var dismiss
 
     public init() {}

--- a/OTPKit/Features/TripPlanner/TripPlannerView.swift
+++ b/OTPKit/Features/TripPlanner/TripPlannerView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 public struct TripPlannerView: View {
-    @ObservedObject private var locationManagerService = TripPlannerService.shared
+    @EnvironmentObject private var locationManagerService: TripPlannerService
 
     public init() {}
 
@@ -43,4 +43,5 @@ public struct TripPlannerView: View {
 
 #Preview {
     TripPlannerView()
+        .environmentObject(PreviewHelpers.buildTripPlannerService())
 }

--- a/OTPKit/Features/TripPlanner/TripPlannerView.swift
+++ b/OTPKit/Features/TripPlanner/TripPlannerView.swift
@@ -8,14 +8,14 @@
 import SwiftUI
 
 public struct TripPlannerView: View {
-    @EnvironmentObject private var locationManagerService: TripPlannerService
+    @EnvironmentObject private var tripPlanner: TripPlannerService
 
     public init() {}
 
     public var body: some View {
         VStack {
             Button(action: {
-                locationManagerService.isStepsViewPresented = true
+                tripPlanner.isStepsViewPresented = true
             }, label: {
                 Text("Start")
             })
@@ -27,7 +27,7 @@ public struct TripPlannerView: View {
             .padding(.horizontal, 16)
 
             Button(action: {
-                locationManagerService.resetTripPlanner()
+                tripPlanner.resetTripPlanner()
             }, label: {
                 Text("Cancel")
             })

--- a/OTPKit/Features/TripPlanner/TripPlannerView.swift
+++ b/OTPKit/Features/TripPlanner/TripPlannerView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 public struct TripPlannerView: View {
-    @ObservedObject private var locationManagerService = LocationManagerService.shared
+    @ObservedObject private var locationManagerService = TripPlannerService.shared
 
     public init() {}
 

--- a/OTPKit/Previews/PreviewHelpers.swift
+++ b/OTPKit/Previews/PreviewHelpers.swift
@@ -6,8 +6,18 @@
 //
 
 import SwiftUI
+import CoreLocation
+import MapKit
 
 class PreviewHelpers {
+    static func buildTripPlannerService() -> TripPlannerService {
+        TripPlannerService(
+            apiClient: RestAPI(baseURL: URL(string: "https://otp.prod.sound.obaweb.org/otp/routers/default/")!),
+            locationManager: CLLocationManager(),
+            searchCompleter: MKLocalSearchCompleter()
+        )
+    }
+
     static func buildLeg() -> Leg {
         Leg(
             startTime: Date(),

--- a/OTPKit/Services/TripPlannerService.swift
+++ b/OTPKit/Services/TripPlannerService.swift
@@ -10,11 +10,6 @@ import MapKit
 import SwiftUI
 
 public final class TripPlannerService: NSObject, ObservableObject {
-    public static let shared = TripPlannerService(
-        apiClient: RestAPI(baseURL: URL(string: "https://otp.prod.sound.obaweb.org/otp/routers/default/")!),
-        locationManager: CLLocationManager(),
-        searchCompleter: MKLocalSearchCompleter()
-    )
 
     // MARK: - Properties
 
@@ -59,7 +54,7 @@ public final class TripPlannerService: NSObject, ObservableObject {
 
     // MARK: - Initialization
 
-    init(apiClient: RestAPI, locationManager: CLLocationManager, searchCompleter: MKLocalSearchCompleter) {
+    public init(apiClient: RestAPI, locationManager: CLLocationManager, searchCompleter: MKLocalSearchCompleter) {
         self.apiClient = apiClient
         self.locationManager = locationManager
         self.searchCompleter = searchCompleter

--- a/OTPKit/Services/TripPlannerService.swift
+++ b/OTPKit/Services/TripPlannerService.swift
@@ -1,5 +1,5 @@
 //
-//  LocationManagerService.swift
+//  TripPlannerService.swift
 //  OTPKit
 //
 //  Created by Hilmy Veradin on 18/07/24.
@@ -9,8 +9,8 @@ import Foundation
 import MapKit
 import SwiftUI
 
-public final class LocationManagerService: NSObject, ObservableObject {
-    public static let shared = LocationManagerService()
+public final class TripPlannerService: NSObject, ObservableObject {
+    public static let shared = TripPlannerService()
 
     // MARK: - Properties
 
@@ -275,7 +275,7 @@ public final class LocationManagerService: NSObject, ObservableObject {
 
 // MARK: - MKLocalSearchCompleterDelegate
 
-extension LocationManagerService: MKLocalSearchCompleterDelegate {
+extension TripPlannerService: MKLocalSearchCompleterDelegate {
     public func completerDidUpdateResults(_ completer: MKLocalSearchCompleter) {
         completions.removeAll()
 
@@ -310,7 +310,7 @@ extension LocationManagerService: MKLocalSearchCompleterDelegate {
 
 // MARK: - CLLocationManagerDelegate
 
-extension LocationManagerService: CLLocationManagerDelegate {
+extension TripPlannerService: CLLocationManagerDelegate {
     public func locationManager(_: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
         guard let location = locations.last else { return }
         DispatchQueue.main.async {
@@ -337,7 +337,7 @@ extension LocationManagerService: CLLocationManagerDelegate {
 
 // MARK: - Service Extension
 
-extension LocationManagerService {
+extension TripPlannerService {
     func formatCoordinate(_ coordinate: CLLocationCoordinate2D?) -> String {
         guard let coordinate else { return "" }
         return String(format: "%.4f,%.4f", coordinate.latitude, coordinate.longitude)

--- a/OTPKitDemo/MapView.swift
+++ b/OTPKitDemo/MapView.swift
@@ -11,7 +11,7 @@ import SwiftUI
 
 public struct MapView: View {
     @StateObject private var sheetEnvironment = OriginDestinationSheetEnvironment()
-    @ObservedObject private var locationManagerService = LocationManagerService.shared
+    @ObservedObject private var locationManagerService = TripPlannerService.shared
 
     @State private var position: MapCameraPosition = .userLocation(fallback: .automatic)
     @State private var directionSheetDetent: PresentationDetent = .fraction(0.2)

--- a/OTPKitDemo/OTPKitDemoApp.swift
+++ b/OTPKitDemo/OTPKitDemoApp.swift
@@ -16,12 +16,21 @@
 
 import OTPKit
 import SwiftUI
+import CoreLocation
+import MapKit
 
 @main
 struct OTPKitDemoApp: App {
+    let tripPlannerService = TripPlannerService(
+        apiClient: RestAPI(baseURL: URL(string: "https://otp.prod.sound.obaweb.org/otp/routers/default/")!),
+        locationManager: CLLocationManager(),
+        searchCompleter: MKLocalSearchCompleter()
+    )
+
     var body: some Scene {
         WindowGroup {
             MapView()
+                .environmentObject(tripPlannerService)
         }
     }
 }


### PR DESCRIPTION
Refactors parts of the OTPKit codebase to make integration into another app and testing both much easier. The key changes here are:

* Rename `LocationManagerService` to `TripPlannerService` to better reflect its purpose
* Inject all of TripPlannerService's dependencies into it via initializer 
* Remove the pre-defined TripPlannerService singleton
* Create a new TripPlannerService singleton in the OTPKitDemo project and inject it into the OTPKit object hierarchy

