### PR TITLE
Fix TestFlight Crash

### DIFF
--- a/Sources/OTPKit/Services/TripPlannerService.swift
+++ b/Sources/OTPKit/Services/TripPlannerService.swift
@@ -300,19 +300,9 @@ public final class TripPlannerService: NSObject {
 
     // MARK: - User Location Methods
 
-    public func checkLocationAuthorization() async {
-        let status = await locationManager.authorizationStatus
-        switch status {
-        case .notDetermined:
-            locationManager.requestWhenInUseAuthorization()
-        case .restricted, .denied:
-            // Handle restricted or denied
-            break
-        case .authorizedAlways, .authorizedWhenInUse:
-            locationManager.startUpdatingLocation()
-        @unknown default:
-            break
-        }
+    public func checkLocationAuthorization() {
+        locationManager.requestWhenInUseAuthorization()
+        locationManager.startUpdatingLocation()
     }
 
 }
@@ -371,12 +361,6 @@ extension TripPlannerService: CLLocationManagerDelegate {
                 longitudinalMeters: 1000
             )
             self.updateCompleterRegion()
-        }
-    }
-
-    public func locationManagerDidChangeAuthorization(_: CLLocationManager) {
-        Task {
-            await checkLocationAuthorization()
         }
     }
 }

--- a/Sources/OTPKit/TripPlannerExtensionView.swift
+++ b/Sources/OTPKit/TripPlannerExtensionView.swift
@@ -49,8 +49,8 @@ public struct TripPlannerExtensionView<MapContent: View>: View {
 
             overlayContent
         }
-        .task {
-            await tripPlanner.checkLocationAuthorization()
+        .onAppear {
+            tripPlanner.checkLocationAuthorization()
         }
     }
 


### PR DESCRIPTION
## Description
Within this PR, there are changes of authorizationStatus. We remove the specific details of authorizationStatus and straight up asking for permission and update users location

"This method can cause UI unresponsiveness if invoked on the main thread. Instead, consider waiting for the ⁠ -locationManagerDidChangeAuthorization: ⁠ callback and checking ⁠ authorizationStatus ⁠ first.
CLLocationManager(<CLLocationManager: 0x600000014000>) for <MKCoreLocationProvider: 0x600003008cf0> did fail with error: Error Domain=kCLErrorDomain Code=1 "(null)""

There are indications that the crash happens because of race condition between locationManagerDidChangeAuthorization and authorizationStatus

## Related Issues
#60 

## Test Instructions
1. Try on the iPad simulator. See if the view rendered directly 