### PR TITLE
Add Current Location Selection as Origin or Destination

### DIFF
--- a/Sources/OTPKit/Features/OriginDestination/Sheets/OriginDestinationSheetView.swift
+++ b/Sources/OTPKit/Features/OriginDestination/Sheets/OriginDestinationSheetView.swift
@@ -192,7 +192,7 @@ public struct OriginDestinationSheetView: View {
                 }, label: {
                     HStack {
                         Image(systemName: "mappin")
-                        Text("Set current location as \(tripPlanner.originDestinationState)")
+                        Text("Set current location as \(tripPlanner.originDestinationState.name.capitalized)")
                     }
                 })
                 .buttonStyle(.plain)

--- a/Sources/OTPKit/Features/OriginDestination/Sheets/OriginDestinationSheetView.swift
+++ b/Sources/OTPKit/Features/OriginDestination/Sheets/OriginDestinationSheetView.swift
@@ -38,6 +38,22 @@ public struct OriginDestinationSheetView: View {
     // Public initializer
     public init() {}
 
+    // MARK: - Shared Actions
+    private func updateTripPlanner(for location: Location) {
+        tripPlanner.appendMarker(location: location)
+        tripPlanner.addOriginDestinationData()
+    }
+    
+    private func onLocationSelection(for location: Location) {
+        updateTripPlanner(for: location)
+        switch UserDefaultsServices.shared.saveRecentLocations(data: location) {
+        case .success:
+            dismiss()
+        case .failure:
+            break
+        }
+    }
+    
     private func favoriteSectionConfirmationDialog() -> some View {
         Group {
             Button(action: {
@@ -71,8 +87,7 @@ public struct OriginDestinationSheetView: View {
                 HStack {
                     ForEach(sheetEnvironment.favoriteLocations, content: { location in
                         FavoriteView(title: location.title, imageName: "mappin", tapAction: {
-                            tripPlanner.appendMarker(location: location)
-                            tripPlanner.addOriginDestinationData()
+                            updateTripPlanner(for: location)
                             dismiss()
                         }, longTapAction: {
                             isShowFavoriteConfirmationDialog = true
@@ -101,8 +116,7 @@ public struct OriginDestinationSheetView: View {
             Section(content: {
                 ForEach(Array(sheetEnvironment.recentLocations.prefix(5)), content: { location in
                     Button {
-                        tripPlanner.appendMarker(location: location)
-                        tripPlanner.addOriginDestinationData()
+                        updateTripPlanner(for: location)
                         dismiss()
                     } label: {
                         VStack(alignment: .leading) {
@@ -125,15 +139,7 @@ public struct OriginDestinationSheetView: View {
         Group {
             ForEach(tripPlanner.completions) { location in
                 Button(action: {
-                    tripPlanner.appendMarker(location: location)
-                    tripPlanner.addOriginDestinationData()
-                    switch UserDefaultsServices.shared.saveRecentLocations(data: location) {
-                    case .success:
-                        dismiss()
-                    case .failure:
-                        break
-                    }
-
+                    onLocationSelection(for: location)
                 }, label: {
                     VStack(alignment: .leading) {
                         Text(location.title)
@@ -150,15 +156,7 @@ public struct OriginDestinationSheetView: View {
         Group {
             if let userLocation = tripPlanner.currentLocation {
                 Button(action: {
-                    tripPlanner.appendMarker(location: userLocation)
-                    tripPlanner.addOriginDestinationData()
-                    switch UserDefaultsServices.shared.saveRecentLocations(data: userLocation) {
-                    case .success:
-                        dismiss()
-                    case .failure:
-                        break
-                    }
-
+                    onLocationSelection(for: userLocation)
                 }, label: {
                     VStack(alignment: .leading) {
                         Text("My Location")
@@ -186,9 +184,37 @@ public struct OriginDestinationSheetView: View {
         .buttonStyle(PlainButtonStyle())
     }
 
+    private func currentLocationAsOriginDestination() -> some View {
+        Group {
+            if let location = tripPlanner.currentLocation {
+                Button(action: {
+                    onLocationSelection(for: location)
+                }, label: {
+                    HStack {
+                        Image(systemName: "mappin")
+                        Text("Set current location as \(tripPlanner.originDestinationState)")
+                    }
+                })
+                .buttonStyle(.plain)
+            } else {
+                EmptyView()
+            }
+        }
+    }
+    
+    private func locationSelectionSection() -> some View {
+        Section(content: {
+            selectLocationBasedOnMap()
+            currentLocationAsOriginDestination()
+        }, header: {
+            Text("Select Location")
+                .textCase(.none)
+        })
+    }
+    
     public var body: some View {
         VStack {
-            PageHeaderView(text: "Change Stop") {
+            PageHeaderView(text: "Choose \(tripPlanner.originDestinationState.name.capitalized)") {
                 dismiss()
             }
             .padding()
@@ -200,7 +226,7 @@ public struct OriginDestinationSheetView: View {
                 if search.isEmpty, isSearchFocused {
                     currentUserSection()
                 } else if search.isEmpty {
-                    selectLocationBasedOnMap()
+                    locationSelectionSection()
                     favoritesSection()
                     recentsSection()
                 } else {

--- a/Sources/OTPKit/Models/OriginDestination/OriginDestinationState.swift
+++ b/Sources/OTPKit/Models/OriginDestination/OriginDestinationState.swift
@@ -15,3 +15,14 @@ public enum OriginDestinationState {
     case origin
     case destination
 }
+
+public extension OriginDestinationState {
+    var name: String {
+        switch self {
+        case .origin:
+            return "origin"
+        case .destination:
+            return "destination"
+        }
+    }
+}


### PR DESCRIPTION
## Description
This PR provides an option for the selection of the current location as an origin or destination based on the context. 

Some minor enhancements :
1. The title of the sheet is changed based on the selection context [Origin - Destination]
2. Create a new section called Select Location consisting of [Current Location - Choose on Map]
3. For`TripPlannerService`,  remove depending on direct string value and use the added name property to `OriginDestinationState`  

## Related Issues
#70 

## Media


https://github.com/user-attachments/assets/7c970dde-3e78-4c08-9250-6fcd196b0fb3



