### PR TITLE
Enhance Walking Guidance in DirectionLegWalkView 

### DIFF
--- a/Sources/OTPKit/Features/TripPlanner/Direction/DirectionLegWalkView.swift
+++ b/Sources/OTPKit/Features/TripPlanner/Direction/DirectionLegWalkView.swift
@@ -9,27 +9,72 @@ import SwiftUI
 
 struct DirectionLegWalkView: View {
     let leg: Leg
+    @State private var showSteps = false
 
     var body: some View {
-        HStack(spacing: 24) {
-            Image(systemName: "figure.walk")
-                .font(.system(size: 24))
-                .padding()
-                .frame(width: 40)
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 16) {
+                Image(systemName: "figure.walk")
+                    .font(.system(size: 24))
+                    .padding()
+                    .frame(width: 40)
 
-            VStack(alignment: .leading, spacing: 4) {
-                Text("Walk to \(leg.to.name)")
-                    .font(.title3)
-                    .fontWeight(.bold)
-                    .fixedSize(horizontal: false, vertical: true)
-                Text(
-                    Formatters.formatDistance(Int(leg.distance)) +
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Walk to \(leg.to.name)")
+                        .font(.title3)
+                        .fontWeight(.bold)
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    Text(
+                        Formatters.formatDistance(Int(leg.distance)) +
                         ", about " +
                         Formatters.formatTimeDuration(leg.duration)
-                )
-                .foregroundStyle(.gray)
-                .fixedSize(horizontal: false, vertical: true)
+                    )
+                    .foregroundStyle(.gray)
+                    .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Spacer()
+
+                // Toggle Button
+                if let steps = leg.steps, !steps.isEmpty {
+                    Button(action: { showSteps.toggle() }) {
+                        Image(systemName: showSteps ? "chevron.down.circle.fill" : "chevron.right.circle.fill")
+                            .font(.system(size: 20))
+                            .foregroundColor(.blue)
+                    }
+                    .buttonStyle(PlainButtonStyle())
+                }
             }
+
+            //MARK: Expandable Steps List View
+            if showSteps, let steps = leg.steps {
+                VStack(alignment: .leading, spacing: 6) {
+                    ForEach(steps, id: \.self) { step in
+                        HStack(alignment: .top, spacing: 8) {
+                            Image(systemName: "mappin.circle.fill")
+                                .foregroundColor(.blue)
+                                .frame(width: 20)
+
+                            Text(stepDescription(for: step))
+                                .font(.subheadline)
+                                .foregroundColor(.gray)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                    }
+                }
+                .padding(.leading, 40)
+                .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+        }
+    }
+
+    /// Generates a user-friendly step description.
+    private func stepDescription(for step: Step) -> String {
+        if let direction = step.relativeDirection {
+            return "\(direction.capitalized) onto \(step.streetName), walk \(Formatters.formatDistance(Int(step.distance)))."
+        } else {
+            return "Walk along \(step.streetName) for \(Formatters.formatDistance(Int(step.distance)))."
         }
     }
 }


### PR DESCRIPTION
## Description
I observed that in the response(OTPResponse) from OTP api while planning a trip, there was a steps option available for walking legs, but it was not displayed in the Walk View. To enhance the user experience, I have added a toggle feature that allows users to view or hide the detailed steps for walking directions.✨

#### Let me know if this is good or any adjustments are needed! 😊


Changes Made
	•	Added a toggle button to show/hide step-by-step walking directions.

## Media 🎥
https://github.com/user-attachments/assets/e4c0b26e-b298-4133-8c61-40b73979e0fc




