### PR TITLE
Add: OTPThemeConfiguration and OTPConfiguration models

### DIFF
--- a/Sources/OTPKit/OTPKitCore/Models/OTPThemeConfiguration.swift
+++ b/Sources/OTPKit/OTPKitCore/Models/OTPThemeConfiguration.swift
@@ -1,0 +1,31 @@
+//
+//  OTPThemeConfiguration.swift
+//  OTPKit
+//
+//  Created by Manu on 2025-07-05.
+//
+
+import SwiftUI
+import UIKit
+
+public struct OTPThemeConfiguration {
+    public let primaryColor: Color
+    public let secondaryColor: Color
+    public let backgroundColor: Color
+    public let textColor: Color
+    public let cornerRadius: CGFloat
+
+    public init(
+        primaryColor: Color = .blue,
+        secondaryColor: Color = .gray,
+        backgroundColor: Color = Color(UIColor.systemBackground),
+        textColor: Color = Color(UIColor.label),
+        cornerRadius: CGFloat = 12
+    ) {
+        self.primaryColor = primaryColor
+        self.secondaryColor = secondaryColor
+        self.backgroundColor = backgroundColor
+        self.textColor = textColor
+        self.cornerRadius = cornerRadius
+    }
+}

--- a/Sources/OTPKit/OTPKitCore/OTPConfiguration.swift
+++ b/Sources/OTPKit/OTPKitCore/OTPConfiguration.swift
@@ -1,0 +1,30 @@
+//
+//  OTPConfiguration.swift
+//  OTPKit
+//
+//  Created by Manu on 2025-07-05.
+//
+import MapKit
+import SwiftUI
+
+public struct OTPConfiguration {
+    public let otpServerURL: URL
+    public let region: MapCameraPosition
+    public let enabledTransportModes: [TransportMode]
+    public let themeConfiguration: OTPThemeConfiguration
+
+    public init(
+        otpServerURL: URL,
+        enabledTransportModes: [TransportMode] = TransportMode.allCases,
+        themeConfiguration: OTPThemeConfiguration = OTPThemeConfiguration(),
+        maxRecentLocations: Int = 10,
+        region: MapCameraPosition
+
+
+    ) {
+        self.otpServerURL = otpServerURL
+        self.enabledTransportModes = enabledTransportModes
+        self.themeConfiguration = themeConfiguration
+        self.region = region
+    }
+}


### PR DESCRIPTION
## Description

This PR introduces two foundational models for OTPKit:

- `OTPThemeConfiguration`: Provides a customizable theme setup using SwiftUI and UIKit colors.
- `OTPConfiguration`: Configuration object containing OTP API endpoint, enabled modes, map region, and theme settings.

These models will be used across the OTPKit components to ensure consistent configuration and theming.

## Related Issues

None yet. This PR introduces base models that future issues and features will build upon.