### PR TITLE
Add Map Bottom Controls Overlay

### DIFF
--- a/Sources/OTPKit/OTPKitCore/Enums/LocationMode.swift
+++ b/Sources/OTPKit/OTPKitCore/Enums/LocationMode.swift
@@ -1,0 +1,11 @@
+//
+//  LocationMode.swift
+//  OTPKit
+//
+//  Created by Manu on 2025-07-06.
+//
+
+public enum LocationMode {
+    case origin
+    case destination
+}

--- a/Sources/OTPKit/OTPKitUI/Components/BottomControlsOverlay.swift
+++ b/Sources/OTPKit/OTPKitUI/Components/BottomControlsOverlay.swift
@@ -7,6 +7,15 @@
 
 import SwiftUI
 
+/// A reusable overlay view that provides key trip-planning controls,
+/// including transport mode selection, origin/destination inputs, and action buttons.
+///
+/// - Displays mode selection buttons (e.g. transit, walk, bike, car)
+/// - Allows users to choose "From" and "To" locations
+/// - Provides quick access to search and additional trip options
+/// - Includes a "Directions" button to trigger trip planning
+///
+/// Designed to sit at the bottom of the map screen in trip planning UI.
 struct BottomControlsOverlay: View {
     @EnvironmentObject private var viewModel: TripPlanningModel
     @Binding var selectedMode: LocationMode

--- a/Sources/OTPKit/OTPKitUI/Components/BottomControlsOverlay.swift
+++ b/Sources/OTPKit/OTPKitUI/Components/BottomControlsOverlay.swift
@@ -1,0 +1,122 @@
+//
+//  BottomControlsOverlay.swift
+//  OTPKit
+//
+//  Created by Manu on 2025-07-06.
+//
+
+import SwiftUI
+
+struct BottomControlsOverlay: View {
+    @EnvironmentObject private var viewModel: TripPlanningModel
+    @Binding var selectedMode: LocationMode
+    
+    private let transportModes: [(mode: TransportMode, icon: String)] = [
+        (.transit, "tram.fill"),
+        (.walk, "figure.walk"),
+        (.bike, "bicycle"),
+        (.car, "car.fill")
+    ]
+    
+    var body: some View {
+        VStack(spacing: 12) {
+            // Transport Mode Selection
+            HStack(spacing: 12) {
+                ForEach(transportModes, id: \.mode) { config in
+                    TransportModeButton(
+                        mode: config.mode,
+                        icon: config.icon,
+                        isSelected: viewModel.selectedTransportMode == config.mode
+                    ) {
+                        viewModel.selectTransportMode(config.mode)
+                    }
+                }
+            }
+            .padding(.horizontal, 4)
+
+            // Location selection buttons stacked vertically
+            VStack(spacing: 8) {
+                LocationButton(
+                    title: "From",
+                    subtitle: viewModel.selectedOrigin?.title ?? "Current location",
+                    icon: "location.fill",
+                    isSelected: selectedMode == .origin,
+                    hasLocation: viewModel.selectedOrigin != nil,
+                    action: {
+                        selectedMode = .origin
+                    }
+                )
+                LocationButton(
+                    title: "To",
+                    subtitle: viewModel.selectedDestination?.title ?? "Choose destination",
+                    icon: "mappin",
+                    isSelected: selectedMode == .destination,
+                    hasLocation: viewModel.selectedDestination != nil,
+                    action: {
+                        selectedMode = .destination
+                    }
+                )
+            }
+
+            // Full width Search Button
+            Button(action: {
+                viewModel.present(.search)
+            }) {
+                HStack {
+                    Image(systemName: "magnifyingglass")
+                        .font(.system(size: 16, weight: .medium))
+                    Text("Search")
+                        .font(.system(size: 16, weight: .medium))
+                }
+                .foregroundColor(.primary)
+                .frame(maxWidth: .infinity)
+                .frame(height: 36)
+                .background(Color(.systemGray6))
+                .cornerRadius(8)
+            }
+
+            // Action buttons
+            HStack(spacing: 8) {
+                // More Options Button
+                Button(action: viewModel.showLocationOptions) {
+                    HStack(spacing: 6) {
+                        Image(systemName: "ellipsis")
+                            .font(.system(size: 14, weight: .medium))
+                        Text("Options")
+                            .font(.system(size: 14, weight: .medium))
+                    }
+                    .foregroundColor(.primary)
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 36)
+                    .background(Color(.systemGray6))
+                    .cornerRadius(8)
+                }
+
+                // Plan Trip Button
+                Button(action: viewModel.planTrip) {
+                    HStack(spacing: 6) {
+                        Image(systemName: "arrow.right")
+                            .font(.system(size: 14, weight: .medium))
+                        Text("Directions")
+                            .font(.system(size: 14, weight: .medium))
+                    }
+                    .foregroundColor(viewModel.canPlanTrip ? .white : .secondary)
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 36)
+                    .background(
+                        viewModel.canPlanTrip ? Color.accentColor : Color(.systemGray5)
+                    )
+                    .cornerRadius(8)
+                }
+                .disabled(!viewModel.canPlanTrip)
+            }
+        }
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: 16)
+                .fill(.ultraThinMaterial)
+                .shadow(color: .black.opacity(0.1), radius: 8, x: 0, y: -4)
+        )
+        .padding(.horizontal, 16)
+    }
+}

--- a/Sources/OTPKit/OTPKitUI/Components/LocationButton.swift
+++ b/Sources/OTPKit/OTPKitUI/Components/LocationButton.swift
@@ -1,0 +1,50 @@
+//
+//  LocationButton.swift
+//  OTPKit
+//
+//  Created by Manu on 2025-07-06.
+//
+import SwiftUI
+
+struct LocationButton: View {
+    let title: String
+    let subtitle: String
+    let icon: String
+    let isSelected: Bool
+    let hasLocation: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 8) {
+                Image(systemName: icon)
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundColor(isSelected ? .accentColor : .secondary)
+                    .frame(width: 16)
+
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(title)
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundColor(.secondary)
+                    Text(subtitle)
+                        .font(.system(size: 14))
+                        .foregroundColor(hasLocation ? .primary : .secondary)
+                        .lineLimit(1)
+                }
+
+                Spacer()
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(isSelected ? Color.accentColor.opacity(0.1) : Color(.systemGray6))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8)
+                            .stroke(isSelected ? Color.accentColor.opacity(0.3) : Color.clear, lineWidth: 1)
+                    )
+            )
+        }
+        .buttonStyle(PlainButtonStyle())
+    }
+}

--- a/Sources/OTPKit/OTPKitUI/Components/TransportModeButton.swift
+++ b/Sources/OTPKit/OTPKitUI/Components/TransportModeButton.swift
@@ -1,0 +1,28 @@
+//
+//  TransportModeButton.swift
+//  OTPKit
+//
+//  Created by Manu on 2025-07-14.
+//
+import SwiftUI
+
+struct TransportModeButton: View {
+    let mode: TransportMode
+    let icon: String
+    let isSelected: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: icon)
+                .font(.system(size: 18, weight: .medium))
+                .foregroundColor(isSelected ? .white : .primary)
+                .frame(width: 44, height: 36)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(isSelected ? Color.accentColor : Color(.systemGray6))
+                )
+        }
+        .buttonStyle(PlainButtonStyle())
+    }
+}


### PR DESCRIPTION
## Description
Added a new bottom controls panel for the map screen that helps users plan their trips easily. The new UI includes:

- Transport mode buttons (transit, walk, bike, car)
- From/To location selectors
- Quick search button
- Trip options and directions buttons

## Media
<img width="1023" height="556" alt="Screenshot 2025-07-20 at 12 31 58 AM" src="https://github.com/user-attachments/assets/20340d86-3449-4cf2-9e93-93225a2146eb" />

https://github.com/user-attachments/assets/abcc1935-51d4-4e0a-9be0-c668616b475d

