### PR TITLE
Fixes a logic bug in the `relevantLegs` computed property of Itinerary.swift

### DIFF
--- a/OTPKit/Sources/OTPKit/Core/Models/TripPlanner/Itinerary.swift
+++ b/OTPKit/Sources/OTPKit/Core/Models/TripPlanner/Itinerary.swift
@@ -58,7 +58,7 @@ public struct Itinerary: Codable, Hashable {
     public var relevantLegs: [Leg] {
         legs.filter { leg in
             if leg.walkMode {
-                return leg.duration < 60
+                return leg.duration > 60
             } else {
                 return true
             }


### PR DESCRIPTION
I flipped the logic: it only showed walks less than 1 minute instead of longer than 1 minute.