### PR TITLE
Fix text contrast on itinerary previews

### DIFF
--- a/OTPKit/Sources/OTPKit/Presentation/Sheets/TripPlanner/Components/ItineraryLegs/ItineraryLegVehicleView.swift
+++ b/OTPKit/Sources/OTPKit/Presentation/Sheets/TripPlanner/Components/ItineraryLegs/ItineraryLegVehicleView.swift
@@ -26,7 +26,7 @@ struct ItineraryLegVehicleView: View {
                 .clipShape(RoundedRectangle(cornerRadius: 4))
 
             Image(systemName: imageName)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(.primary)
         }.frame(minHeight: 40)
     }
 
@@ -59,7 +59,7 @@ struct ItineraryLegVehicleView: View {
             return color
         }
 
-        return Color(.systemFill)
+        return Color(.darkGray)
     }
 }
 

--- a/OTPKit/Sources/OTPKit/Presentation/Sheets/TripPlanner/Components/ItineraryLegs/ItineraryLegWalkView.swift
+++ b/OTPKit/Sources/OTPKit/Presentation/Sheets/TripPlanner/Components/ItineraryLegs/ItineraryLegWalkView.swift
@@ -21,7 +21,7 @@ struct ItineraryLegWalkView: View {
         .padding(.horizontal, 8)
         .padding(.vertical, 4)
         .background(Color.gray.opacity(0.2))
-        .foregroundStyle(.gray)
+        .foregroundStyle(.primary)
         .clipShape(RoundedRectangle(cornerRadius: 8))
         .frame(height: 40)
     }


### PR DESCRIPTION
## Description
This PR fixes the low-contrast text issue on itinerary previews reported in #132.

## Changes Made
- Improved walk time text contrast by changing from `.foregroundStyle(.gray)` to `.foregroundStyle(.primary)` in `ItineraryLegWalkView`
- Fixed vehicle icon contrast by changing from `.foregroundStyle(.secondary)` to `.foregroundStyle(.primary)` in `ItineraryLegVehicleView`
- Changed fallback background color from `Color(.systemFill)` to `Color(.darkGray)` for better readability when route colors are not provided

## Screenshots

### Before
<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/ec3d0c77-a54f-4b34-a83a-f386bbd1c102" />

### After
<img width="739" height="1600" alt="image" src="https://github.com/user-attachments/assets/02522978-8111-44c3-a16c-d2861b8cc6cb" />

## Testing
Tested on iPhone with Seattle transit data (SeaTac Airport to Space Needle route).

Fixes #132