### PR TITLE
Add embark/debark icons to transit stops

### DIFF
--- a/OTPKit/Sources/OTPKit/Core/Map/MapCoordinator.swift
+++ b/OTPKit/Sources/OTPKit/Core/Map/MapCoordinator.swift
@@ -302,28 +302,30 @@ public class MapCoordinator: ObservableObject {
     }
 
     private func addStationAnnotations(for leg: Leg, index: Int, totalLegs: Int) {
-        // Add station annotation for "from" location if it's a transit stop
+        // Only add embark/debark markers for transit legs
+        guard leg.transitLeg == true else { return }
+        // Add annotation for "from" location (embark point)
         if shouldShowStation(for: leg.from) {
             mapProvider.addAnnotation(
                 coordinate: CLLocationCoordinate2D(latitude: leg.from.lat, longitude: leg.from.lon),
                 title: leg.from.name,
                 subtitle: nil,
                 identifier: "station_from_\(index)",
-                type: .transitStop,
+                type: .embark,
                 routeName: nil,
                 routeBackgroundColor: nil,
                 routeTextColor: nil
             )
         }
 
-        // Add "to" location only for the last leg
-        if index == totalLegs - 1 && shouldShowStation(for: leg.to) {
+        // Add annotation for "to" location (debark point)
+        if shouldShowStation(for: leg.to) {
             mapProvider.addAnnotation(
                 coordinate: CLLocationCoordinate2D(latitude: leg.to.lat, longitude: leg.to.lon),
                 title: leg.to.name,
                 subtitle: nil,
                 identifier: "station_to_\(index)",
-                type: .transitStop,
+                type: .debark,
                 routeName: nil,
                 routeBackgroundColor: nil,
                 routeTextColor: nil

--- a/OTPKit/Sources/OTPKit/Core/Map/OTPMapProvider.swift
+++ b/OTPKit/Sources/OTPKit/Core/Map/OTPMapProvider.swift
@@ -137,6 +137,8 @@ public enum OTPAnnotationType {
     case currentLocation
     case searchResult
     case routeLegend
+    case embark        // NEW: Where to board transit
+    case debark        // NEW: Where to get off transit
 
     /// Returns the appropriate color for this annotation type
     public var color: Color {
@@ -153,6 +155,10 @@ public enum OTPAnnotationType {
             return .blue
         case .searchResult:
             return .gray
+        case .embark:
+            return .blue      // NEW: Blue for boarding (like Apple Maps)
+        case .debark:
+            return .orange    // NEW: Orange for exit (like Apple Maps)
         case .routeLegend:
             return .clear // Custom view will handle coloring
         }
@@ -169,6 +175,10 @@ public enum OTPAnnotationType {
             return "bus.fill"
         case .transitStation:
             return "tram.fill"
+        case .embark:
+            return "arrow.up.circle.fill"        // NEW: Upward arrow for boarding
+        case .debark:
+            return "arrow.down.circle.fill"      // NEW: Downward arrow for exiting
         case .waypoint:
             return "flag.fill"
         case .currentLocation:


### PR DESCRIPTION
Fixes #128

## Changes
- Added `.embark` and `.debark` annotation types to `OTPAnnotationType`
- Embark points (where to board transit) show blue circle with up arrow (↑)
- Debark points (where to exit transit) show orange circle with down arrow (↓)
- Only transit legs show these markers (walking legs are excluded)

## Screenshots

<img width="300" height="1600" alt="image" src="https://github.com/user-attachments/assets/35c47286-1f0c-4e2f-9aba-2ecbd08b444f" />
<img width="300" height="1600" alt="image" src="https://github.com/user-attachments/assets/8baef696-55db-4c27-a3a0-8eb5c508d15d" />
<img width="300" height="1600" alt="image" src="https://github.com/user-attachments/assets/fa76adfb-542f-469a-aa5e-0ed698456d3e" />


## Implementation Notes
The markers use fixed semantic colors (blue for boarding, orange for exiting) rather than matching route colors. Happy to adjust the styling if you'd prefer a different approach!

## Testing
Tested on iPhone with multiple transit routes in Seattle area.