### PR TITLE
Add OTP 2.x GraphQL API support alongside the 1.x REST API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ The repository contains both a Swift Package (Package.swift) and an Xcode projec
 
 ### API Support Status
 - **OTP 1.x REST API**: ✅ Fully implemented via `RestAPIService`
-- **OTP 2.x GraphQL API**: ❌ Not yet implemented
+- **OTP 2.x GraphQL API**: ✅ Implemented via `GraphQLAPIService` (GTFS GraphQL API `plan` query)
 
 ## Tests and Quality
 
@@ -90,7 +90,8 @@ If either linting or tests fail, the push will be blocked until issues are fixed
     - `MKMapViewAdapter` - MapKit implementation of OTPMapProvider
 - `Network/` - API communication layer
   - `APIService` - Protocol defining trip planning interface
-  - `RestAPIService/RestAPIService` - OTP 1.x REST API implementation (actor-based)
+  - `RestAPIService` - OTP 1.x REST API implementation (actor-based)
+  - `GraphQLAPIService` - OTP 2.x GTFS GraphQL API implementation (actor-based)
   - `URLDataLoader` - Network request handling
 - `Presentation/` - SwiftUI views and ViewModels
   - `OTPView` - Main entry point view that sets up the environment

--- a/Demo/OTPKitDemo/OTPDemoViewController.swift
+++ b/Demo/OTPKitDemo/OTPDemoViewController.swift
@@ -30,7 +30,7 @@ class OTPDemoViewController: UIViewController {
     private let regionInfo: OTPRegionInfo
     private var mapView: MKMapView!
     private var mapProvider: OTPMapProvider?
-    private var apiService: RestAPIService!
+    private var apiService: APIService!
     private var tripPlanner: TripPlanner?
     private var hostingController: UIViewController?
 
@@ -116,8 +116,13 @@ class OTPDemoViewController: UIViewController {
     }
 
     private func setupAPIService() {
-        // Create API service
-        apiService = RestAPIService(baseURL: serverURL)
+        // Create the API service matching the region's OTP server version
+        switch regionInfo.apiType {
+        case .rest:
+            apiService = RestAPIService(baseURL: serverURL)
+        case .graphQL:
+            apiService = GraphQLAPIService(baseURL: serverURL)
+        }
     }
 
     // MARK: - Actions

--- a/Demo/OTPKitDemo/OnboardingViewController.swift
+++ b/Demo/OTPKitDemo/OnboardingViewController.swift
@@ -30,6 +30,14 @@ class OnboardingViewController: UIViewController {
             icon: "building.2.fill",
             url: URL(string: "https://otp.prod.sound.obaweb.org/otp/routers/default/")!,
             center: CLLocationCoordinate2D(latitude: 47.6062, longitude: -122.3321)
+        ),
+        OTPRegionInfo(
+            name: "Seattle (OTP 2.x GraphQL)",
+            description: "Puget Sound region via the OTP 2.x GraphQL API",
+            icon: "building.2.fill",
+            url: URL(string: "https://sound-transit-otp.ibi-transit.com/otp/")!,
+            center: CLLocationCoordinate2D(latitude: 47.6062, longitude: -122.3321),
+            apiType: .graphQL
         )
     ]
 

--- a/Demo/OTPKitDemo/models/OTPRegionInfo.swift
+++ b/Demo/OTPKitDemo/models/OTPRegionInfo.swift
@@ -9,23 +9,33 @@ import Foundation
 import CoreLocation
 
 struct OTPRegionInfo: Codable {
+    /// Which OTP API flavor the region's server speaks.
+    enum APIType: String, Codable {
+        /// OTP 1.x REST API
+        case rest
+        /// OTP 2.x GTFS GraphQL API
+        case graphQL
+    }
+
     let name: String
     let description: String
     let icon: String
     let url: URL
     let center: CLLocationCoordinate2D
+    let apiType: APIType
 
     enum CodingKeys: String, CodingKey {
-        case name, description, icon, url
+        case name, description, icon, url, apiType
         case latitude, longitude
     }
 
-    init(name: String, description: String, icon: String, url: URL, center: CLLocationCoordinate2D) {
+    init(name: String, description: String, icon: String, url: URL, center: CLLocationCoordinate2D, apiType: APIType = .rest) {
         self.name = name
         self.description = description
         self.icon = icon
         self.url = url
         self.center = center
+        self.apiType = apiType
     }
 
     init(from decoder: Decoder) throws {
@@ -37,6 +47,8 @@ struct OTPRegionInfo: Codable {
         let latitude = try container.decode(Double.self, forKey: .latitude)
         let longitude = try container.decode(Double.self, forKey: .longitude)
         center = CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
+        // Regions persisted before apiType existed are REST servers.
+        apiType = try container.decodeIfPresent(APIType.self, forKey: .apiType) ?? .rest
     }
 
     func encode(to encoder: Encoder) throws {
@@ -47,5 +59,6 @@ struct OTPRegionInfo: Codable {
         try container.encode(url, forKey: .url)
         try container.encode(center.latitude, forKey: .latitude)
         try container.encode(center.longitude, forKey: .longitude)
+        try container.encode(apiType, forKey: .apiType)
     }
 }

--- a/OTPKit/Sources/OTPKit/Core/Models/OTP/ErrorResponse.swift
+++ b/OTPKit/Sources/OTPKit/Core/Models/OTP/ErrorResponse.swift
@@ -20,8 +20,9 @@ import OSLog
 /// `ErrorResponse` represents an error structure used across the application to handle and represent
 /// OTP errors uniformly.
 public struct ErrorResponse: Codable, Hashable {
-    /// A unique identifier for the error.
-    public let id: Int
+    /// A unique identifier for the error. Only the OTP 1.x REST API supplies one;
+    /// errors mapped from the OTP 2.x GraphQL API have no id.
+    public let id: Int?
 
     /// A descriptive message associated with the error, providing more detailed information about what went wrong.
     /// This message can be presented to the user or used in debugging to provide context about the error.

--- a/OTPKit/Sources/OTPKit/Core/Models/OTP/Itinerary.swift
+++ b/OTPKit/Sources/OTPKit/Core/Models/OTP/Itinerary.swift
@@ -29,13 +29,13 @@ public struct Itinerary: Codable, Hashable {
     /// End time of the itinerary.
     public let endTime: Date
 
-    /// Total walking time in minutes within the itinerary.
+    /// Total walking time in seconds within the itinerary.
     public let walkTime: Int
 
-    /// Total transit time in minutes within the itinerary.
+    /// Total transit time in seconds within the itinerary.
     public let transitTime: Int
 
-    /// Total waiting time in minutes within the itinerary.
+    /// Total waiting time in seconds within the itinerary.
     public let waitingTime: Int
 
     /// Total walking distance in meters within the itinerary.

--- a/OTPKit/Sources/OTPKit/Network/APIServiceSupport.swift
+++ b/OTPKit/Sources/OTPKit/Network/APIServiceSupport.swift
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy at:
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+// Wire-level plumbing shared by the REST and GraphQL API services.
+
+extension OTPKitError {
+    /// The generic "the server response can't be parsed" API error.
+    static func invalidResponse(statusCode: Int? = nil) -> OTPKitError {
+        .apiError(
+            OTPLoc("error.invalid_response", comment: "Shown when the server response can't be parsed"),
+            statusCode: statusCode
+        )
+    }
+}
+
+extension URLDataLoader {
+    /// Performs the request and returns the response body, throwing
+    /// `OTPKitError.invalidResponse` unless the server returned HTTP 200.
+    func validatedData(for request: URLRequest) async throws -> Data {
+        let (data, response) = try await data(for: request)
+
+        guard
+            let httpResponse = response as? HTTPURLResponse,
+            httpResponse.statusCode == 200
+        else {
+            throw OTPKitError.invalidResponse(statusCode: (response as? HTTPURLResponse)?.statusCode)
+        }
+
+        return data
+    }
+}
+
+extension JSONDecoder {
+    /// A decoder configured for OTP wire responses, whose dates are epoch milliseconds.
+    static func otpDecoder() -> JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .millisecondsSince1970
+        return decoder
+    }
+}
+
+extension URL {
+    /// True if the URL path ends with an OTP REST router segment (`routers/<id>`).
+    var hasOTPRouterPath: Bool {
+        path().contains(#/routers/[^/]+/?$/#)
+    }
+
+    /// Returns a URL with any trailing `routers/<id>` segment removed.
+    func strippingOTPRouterPath() -> URL {
+        guard hasOTPRouterPath else { return self }
+
+        var urlString = absoluteString
+        if let routersRange = urlString.range(of: "routers/[^/]+/?$", options: .regularExpression) {
+            urlString.removeSubrange(routersRange)
+        }
+
+        return URL(string: urlString) ?? self
+    }
+}

--- a/OTPKit/Sources/OTPKit/Network/GraphQLAPIService.swift
+++ b/OTPKit/Sources/OTPKit/Network/GraphQLAPIService.swift
@@ -50,31 +50,15 @@ public actor GraphQLAPIService: APIService {
 
         Logger.main.info("Fetching trip plan via GraphQL: \(self.endpointURL.absoluteString)")
 
-        let (data, response) = try await dataLoader.data(for: urlRequest)
-
-        guard
-            let httpResponse = response as? HTTPURLResponse,
-            httpResponse.statusCode == 200
-        else {
-            let statusCode = (response as? HTTPURLResponse)?.statusCode
-            throw OTPKitError.apiError(
-                OTPLoc("error.invalid_response", comment: "Shown when the server response can't be parsed"),
-                statusCode: statusCode
-            )
-        }
-
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .millisecondsSince1970
-        let envelope = try decoder.decode(GraphQLResponseEnvelope.self, from: data)
+        let data = try await dataLoader.validatedData(for: urlRequest)
+        let envelope = try JSONDecoder.otpDecoder().decode(GraphQLResponseEnvelope.self, from: data)
 
         if let firstError = envelope.errors?.first {
             throw OTPKitError.apiError(firstError.message)
         }
 
         guard let plan = envelope.data?.plan else {
-            throw OTPKitError.apiError(
-                OTPLoc("error.invalid_response", comment: "Shown when the server response can't be parsed")
-            )
+            throw OTPKitError.invalidResponse()
         }
 
         return OTPResponse(
@@ -93,11 +77,22 @@ public actor GraphQLAPIService: APIService {
             "to": ["lat": request.destination.latitude, "lon": request.destination.longitude],
             "date": request.date.formattedTripDate,
             "time": request.time.formattedTripTime,
-            "transportModes": request.transportModes.map { ["mode": $0.rawValue] },
+            "transportModes": request.transportModes.map { ["mode": graphQLModeName(for: $0)] },
             "arriveBy": request.arriveBy,
             "wheelchair": request.wheelchairAccessible,
             "maxWalkDistance": Double(request.maxWalkDistance)
         ]
+    }
+
+    /// The GraphQL `Mode` enum value for a transport mode. `TransportMode.rawValue` is the
+    /// OTP 1.x REST token, which mostly — but not always — matches the GraphQL vocabulary.
+    private static func graphQLModeName(for mode: TransportMode) -> String {
+        switch mode {
+        case .bike:
+            return "BICYCLE"
+        case .transit, .walk, .car:
+            return mode.rawValue
+        }
     }
 
     /// Synthesizes the REST-style request parameters echoed back in `OTPResponse`.
@@ -120,11 +115,7 @@ public actor GraphQLAPIService: APIService {
     /// - Parameter url: The base URL to normalize
     /// - Returns: The GraphQL endpoint URL
     private static func normalizeEndpointURL(_ url: URL) -> URL {
-        var urlString = url.absoluteString
-
-        if let routersRange = urlString.range(of: "routers/[^/]+/?$", options: .regularExpression) {
-            urlString.removeSubrange(routersRange)
-        }
+        var urlString = url.strippingOTPRouterPath().absoluteString
 
         while urlString.hasSuffix("/") {
             urlString.removeLast()

--- a/OTPKit/Sources/OTPKit/Network/GraphQLAPIService.swift
+++ b/OTPKit/Sources/OTPKit/Network/GraphQLAPIService.swift
@@ -1,0 +1,205 @@
+/*
+ * Copyright (C) Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy at:
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+import OSLog
+
+/// Actor-based GraphQL API client for OTP 2.x trip planning via the GTFS GraphQL API.
+public actor GraphQLAPIService: APIService {
+    public nonisolated let baseURL: URL
+    public nonisolated let dataLoader: URLDataLoader
+
+    /// The GraphQL endpoint the service POSTs to, derived from `baseURL`.
+    public nonisolated let endpointURL: URL
+
+    /// Creates a GraphQL API client
+    /// - Parameters:
+    ///   - baseURL: Base URL of the OTP server, e.g. `https://otp.example.com/otp/`
+    ///   - dataLoader: Network loader (defaults to `URLSession.shared`)
+    public init(
+        baseURL: URL,
+        dataLoader: URLDataLoader = URLSession.shared
+    ) {
+        self.baseURL = baseURL
+        self.dataLoader = dataLoader
+        self.endpointURL = Self.normalizeEndpointURL(baseURL)
+    }
+
+    /// Fetches a trip plan using a `TripPlanRequest`
+    public func fetchPlan(_ request: TripPlanRequest) async throws -> OTPResponse {
+        var urlRequest = URLRequest(url: endpointURL)
+        urlRequest.httpMethod = "POST"
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        urlRequest.httpBody = try JSONSerialization.data(withJSONObject: [
+            "query": Self.planQuery,
+            "variables": Self.planVariables(for: request)
+        ])
+
+        Logger.main.info("Fetching trip plan via GraphQL: \(self.endpointURL.absoluteString)")
+
+        let (data, response) = try await dataLoader.data(for: urlRequest)
+
+        guard
+            let httpResponse = response as? HTTPURLResponse,
+            httpResponse.statusCode == 200
+        else {
+            let statusCode = (response as? HTTPURLResponse)?.statusCode
+            throw OTPKitError.apiError(
+                OTPLoc("error.invalid_response", comment: "Shown when the server response can't be parsed"),
+                statusCode: statusCode
+            )
+        }
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .millisecondsSince1970
+        let envelope = try decoder.decode(GraphQLResponseEnvelope.self, from: data)
+
+        if let firstError = envelope.errors?.first {
+            throw OTPKitError.apiError(firstError.message)
+        }
+
+        guard let plan = envelope.data?.plan else {
+            throw OTPKitError.apiError(
+                OTPLoc("error.invalid_response", comment: "Shown when the server response can't be parsed")
+            )
+        }
+
+        return OTPResponse(
+            requestParameters: Self.requestParameters(for: request),
+            plan: plan.toPlan(),
+            error: plan.toErrorResponse()
+        )
+    }
+
+    // MARK: - Request Building
+
+    /// Builds the GraphQL `variables` payload for a trip plan request.
+    private static func planVariables(for request: TripPlanRequest) -> [String: Any] {
+        [
+            "from": ["lat": request.origin.latitude, "lon": request.origin.longitude],
+            "to": ["lat": request.destination.latitude, "lon": request.destination.longitude],
+            "date": request.date.formattedTripDate,
+            "time": request.time.formattedTripTime,
+            "transportModes": request.transportModes.map { ["mode": $0.rawValue] },
+            "arriveBy": request.arriveBy,
+            "wheelchair": request.wheelchairAccessible,
+            "maxWalkDistance": Double(request.maxWalkDistance)
+        ]
+    }
+
+    /// Synthesizes the REST-style request parameters echoed back in `OTPResponse`.
+    private static func requestParameters(for request: TripPlanRequest) -> RequestParameters {
+        RequestParameters(
+            fromPlace: request.origin.formattedForAPI,
+            toPlace: request.destination.formattedForAPI,
+            time: request.time.formattedTripTime,
+            date: request.date.formattedTripDate,
+            mode: request.transportModesString,
+            arriveBy: request.arriveBy ? "true" : "false",
+            maxWalkDistance: String(request.maxWalkDistance),
+            wheelchair: request.wheelchairAccessible ? "true" : "false"
+        )
+    }
+
+    /// Normalizes the base URL into the GTFS GraphQL endpoint by appending `gtfs/v1`.
+    /// A REST-style trailing `routers/<id>` segment is stripped first so that either
+    /// flavor of server URL works.
+    /// - Parameter url: The base URL to normalize
+    /// - Returns: The GraphQL endpoint URL
+    private static func normalizeEndpointURL(_ url: URL) -> URL {
+        var urlString = url.absoluteString
+
+        if let routersRange = urlString.range(of: "routers/[^/]+/?$", options: .regularExpression) {
+            urlString.removeSubrange(routersRange)
+        }
+
+        while urlString.hasSuffix("/") {
+            urlString.removeLast()
+        }
+
+        if !urlString.hasSuffix("/gtfs/v1") {
+            urlString += "/gtfs/v1"
+        }
+
+        return URL(string: urlString)!
+    }
+
+    // MARK: - GraphQL Query
+
+    /// The GTFS GraphQL API `plan` query. Requests only the fields OTPKit's models consume,
+    /// mirroring what the OTP 1.x REST API returns.
+    static let planQuery = """
+    query TripPlan(
+      $from: InputCoordinates!
+      $to: InputCoordinates!
+      $date: String!
+      $time: String!
+      $transportModes: [TransportMode!]
+      $arriveBy: Boolean
+      $wheelchair: Boolean
+      $maxWalkDistance: Float
+    ) {
+      plan(
+        from: $from
+        to: $to
+        date: $date
+        time: $time
+        transportModes: $transportModes
+        arriveBy: $arriveBy
+        wheelchair: $wheelchair
+        maxWalkDistance: $maxWalkDistance
+      ) {
+        date
+        from { name lon lat vertexType }
+        to { name lon lat vertexType }
+        routingErrors { code description }
+        itineraries {
+          duration
+          startTime
+          endTime
+          walkTime
+          waitingTime
+          walkDistance
+          elevationLost
+          elevationGained
+          numberOfTransfers
+          legs {
+            startTime
+            endTime
+            mode
+            route {
+              shortName
+              type
+              color
+              textColor
+              agency { name }
+            }
+            from { name lon lat vertexType stop { gtfsId code } }
+            to { name lon lat vertexType stop { gtfsId code } }
+            legGeometry { points length }
+            distance
+            transitLeg
+            duration
+            realTime
+            headsign
+            intermediatePlaces { name lon lat vertexType stop { gtfsId code } }
+            steps { distance streetName relativeDirection lon lat }
+          }
+        }
+      }
+    }
+    """
+}

--- a/OTPKit/Sources/OTPKit/Network/GraphQLPlanResponse.swift
+++ b/OTPKit/Sources/OTPKit/Network/GraphQLPlanResponse.swift
@@ -159,7 +159,7 @@ extension GraphQLRoutingError {
         }
 
         // `id` is an OTP 1.x REST wire field with no GraphQL equivalent; consumers key off messageCode.
-        return ErrorResponse(id: -1, message: description, messageCode: messageCode)
+        return ErrorResponse(id: nil, message: description, messageCode: messageCode)
     }
 }
 

--- a/OTPKit/Sources/OTPKit/Network/GraphQLPlanResponse.swift
+++ b/OTPKit/Sources/OTPKit/Network/GraphQLPlanResponse.swift
@@ -15,6 +15,7 @@
  */
 
 import Foundation
+import OSLog
 
 // Internal wire types for the OTP 2.x GTFS GraphQL API `plan` query, plus the
 // mapping that converts them into the public models shared with the REST path.
@@ -153,6 +154,7 @@ extension GraphQLRoutingError {
         case "LOCATION_NOT_FOUND", "NO_STOPS_IN_RANGE":
             messageCode = .locationNotAccessible
         default:
+            Logger.main.warning("Unrecognized OTP routing error code: \(code)")
             messageCode = .unknown
         }
 

--- a/OTPKit/Sources/OTPKit/Network/GraphQLPlanResponse.swift
+++ b/OTPKit/Sources/OTPKit/Network/GraphQLPlanResponse.swift
@@ -142,23 +142,22 @@ extension GraphQLPlan {
 extension GraphQLRoutingError {
     func toErrorResponse() -> ErrorResponse {
         let messageCode: ErrorResponseCode
-        // The ids match the OTP 1.x planner error ids for the equivalent conditions.
-        let id: Int
 
         switch code {
         case "OUTSIDE_BOUNDS":
-            (messageCode, id) = (.outsideBounds, 400)
+            messageCode = .outsideBounds
         case "NO_TRANSIT_CONNECTION", "NO_DIRECT_MODE_CONNECTION":
-            (messageCode, id) = (.pathNotFound, 404)
+            messageCode = .pathNotFound
         case "NO_TRANSIT_CONNECTION_IN_SEARCH_WINDOW", "OUTSIDE_SERVICE_PERIOD":
-            (messageCode, id) = (.noTransitTimes, 406)
+            messageCode = .noTransitTimes
         case "LOCATION_NOT_FOUND", "NO_STOPS_IN_RANGE":
-            (messageCode, id) = (.locationNotAccessible, 470)
+            messageCode = .locationNotAccessible
         default:
-            (messageCode, id) = (.unknown, -1)
+            messageCode = .unknown
         }
 
-        return ErrorResponse(id: id, message: description, messageCode: messageCode)
+        // `id` is an OTP 1.x REST wire field with no GraphQL equivalent; consumers key off messageCode.
+        return ErrorResponse(id: -1, message: description, messageCode: messageCode)
     }
 }
 

--- a/OTPKit/Sources/OTPKit/Network/GraphQLPlanResponse.swift
+++ b/OTPKit/Sources/OTPKit/Network/GraphQLPlanResponse.swift
@@ -1,0 +1,235 @@
+/*
+ * Copyright (C) Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy at:
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+// Internal wire types for the OTP 2.x GTFS GraphQL API `plan` query, plus the
+// mapping that converts them into the public models shared with the REST path.
+
+struct GraphQLResponseEnvelope: Decodable {
+    let data: GraphQLPlanData?
+    let errors: [GraphQLErrorMessage]?
+}
+
+struct GraphQLErrorMessage: Decodable {
+    let message: String
+}
+
+struct GraphQLPlanData: Decodable {
+    let plan: GraphQLPlan?
+}
+
+struct GraphQLPlan: Decodable {
+    let date: Date
+    let from: GraphQLPlace
+    let to: GraphQLPlace
+    let routingErrors: [GraphQLRoutingError]
+    let itineraries: [GraphQLItinerary]
+}
+
+struct GraphQLRoutingError: Decodable {
+    let code: String
+    let description: String
+}
+
+struct GraphQLItinerary: Decodable {
+    let duration: Int
+    let startTime: Date
+    let endTime: Date
+    let walkTime: Int
+    let waitingTime: Int
+    let walkDistance: Double?
+    let elevationLost: Double?
+    let elevationGained: Double?
+    let numberOfTransfers: Int
+    let legs: [GraphQLLeg]
+}
+
+struct GraphQLLeg: Decodable {
+    let startTime: Date
+    let endTime: Date
+    let mode: String
+    let route: GraphQLRoute?
+    let from: GraphQLPlace
+    let to: GraphQLPlace
+    let legGeometry: GraphQLLegGeometry?
+    let distance: Double
+    let transitLeg: Bool?
+    let duration: Double
+    let realTime: Bool?
+    let headsign: String?
+    let intermediatePlaces: [GraphQLPlace]?
+    let steps: [GraphQLStep]?
+}
+
+struct GraphQLRoute: Decodable {
+    let shortName: String?
+    let type: Int?
+    let color: String?
+    let textColor: String?
+    let agency: GraphQLAgency?
+}
+
+struct GraphQLAgency: Decodable {
+    let name: String
+}
+
+struct GraphQLPlace: Decodable {
+    let name: String?
+    let lon: Double
+    let lat: Double
+    let vertexType: String?
+    let stop: GraphQLStop?
+}
+
+struct GraphQLStop: Decodable {
+    let gtfsId: String?
+    let code: String?
+}
+
+struct GraphQLLegGeometry: Decodable {
+    let points: String?
+    let length: Int?
+}
+
+struct GraphQLStep: Decodable {
+    let distance: Double
+    let streetName: String?
+    let relativeDirection: String?
+    let lon: Double
+    let lat: Double
+}
+
+// MARK: - Mapping to public models
+
+extension GraphQLPlan {
+    func toPlan() -> Plan {
+        Plan(
+            date: date,
+            from: from.toPlace(),
+            to: to.toPlace(),
+            itineraries: itineraries.map { $0.toItinerary() }
+        )
+    }
+
+    /// Maps the first actionable routing error to the REST-style `ErrorResponse`, or nil
+    /// when itineraries were found. `WALKING_BETTER_THAN_TRANSIT` is advisory, not a failure.
+    func toErrorResponse() -> ErrorResponse? {
+        guard
+            itineraries.isEmpty,
+            let routingError = routingErrors.first(where: { $0.code != "WALKING_BETTER_THAN_TRANSIT" })
+        else {
+            return nil
+        }
+
+        return routingError.toErrorResponse()
+    }
+}
+
+extension GraphQLRoutingError {
+    func toErrorResponse() -> ErrorResponse {
+        let messageCode: ErrorResponseCode
+        // The ids match the OTP 1.x planner error ids for the equivalent conditions.
+        let id: Int
+
+        switch code {
+        case "OUTSIDE_BOUNDS":
+            (messageCode, id) = (.outsideBounds, 400)
+        case "NO_TRANSIT_CONNECTION", "NO_DIRECT_MODE_CONNECTION":
+            (messageCode, id) = (.pathNotFound, 404)
+        case "NO_TRANSIT_CONNECTION_IN_SEARCH_WINDOW", "OUTSIDE_SERVICE_PERIOD":
+            (messageCode, id) = (.noTransitTimes, 406)
+        case "LOCATION_NOT_FOUND", "NO_STOPS_IN_RANGE":
+            (messageCode, id) = (.locationNotAccessible, 470)
+        default:
+            (messageCode, id) = (.unknown, -1)
+        }
+
+        return ErrorResponse(id: id, message: description, messageCode: messageCode)
+    }
+}
+
+extension GraphQLItinerary {
+    func toItinerary() -> Itinerary {
+        Itinerary(
+            duration: duration,
+            startTime: startTime,
+            endTime: endTime,
+            walkTime: walkTime,
+            transitTime: max(0, duration - walkTime - waitingTime),
+            waitingTime: waitingTime,
+            walkDistance: walkDistance ?? 0,
+            walkLimitExceeded: false,
+            elevationLost: elevationLost ?? 0,
+            elevationGained: elevationGained ?? 0,
+            transfers: numberOfTransfers,
+            legs: legs.map { $0.toLeg() }
+        )
+    }
+}
+
+extension GraphQLLeg {
+    func toLeg() -> Leg {
+        Leg(
+            startTime: startTime,
+            endTime: endTime,
+            mode: mode,
+            routeType: route?.type.flatMap { RouteType(rawValue: $0) },
+            routeColor: route?.color,
+            routeTextColor: route?.textColor,
+            route: route?.shortName,
+            agencyName: route?.agency?.name,
+            from: from.toPlace(),
+            to: to.toPlace(),
+            legGeometry: LegGeometry(points: legGeometry?.points ?? "", length: legGeometry?.length ?? 0),
+            distance: distance,
+            transitLeg: transitLeg,
+            duration: Int(duration.rounded()),
+            realTime: realTime,
+            streetNames: nil,
+            pathway: nil,
+            steps: steps?.map { $0.toStep() },
+            headsign: headsign,
+            intermediateStops: intermediatePlaces?.map { $0.toPlace() }
+        )
+    }
+}
+
+extension GraphQLPlace {
+    func toPlace() -> Place {
+        Place(
+            name: name ?? "",
+            lon: lon,
+            lat: lat,
+            vertexType: vertexType ?? "NORMAL",
+            stopId: stop?.gtfsId,
+            stopCode: stop?.code
+        )
+    }
+}
+
+extension GraphQLStep {
+    func toStep() -> Step {
+        Step(
+            distance: distance,
+            streetName: streetName ?? "",
+            relativeDirection: relativeDirection,
+            elevationChange: nil,
+            lon: lon,
+            lat: lat
+        )
+    }
+}

--- a/OTPKit/Sources/OTPKit/Network/RestAPIService.swift
+++ b/OTPKit/Sources/OTPKit/Network/RestAPIService.swift
@@ -82,22 +82,8 @@ public actor RestAPIService: APIService {
 
         Logger.main.info("Fetching trip plan: \(request.url!.absoluteString)")
 
-        let (data, response) = try await dataLoader.data(for: request)
-
-        guard
-            let httpResponse = response as? HTTPURLResponse,
-            httpResponse.statusCode == 200
-        else {
-            let statusCode = (response as? HTTPURLResponse)?.statusCode
-            throw OTPKitError.apiError(
-                OTPLoc("error.invalid_response", comment: "Shown when the server response can't be parsed"),
-                statusCode: statusCode
-            )
-        }
-
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .millisecondsSince1970
-        return try decoder.decode(OTPResponse.self, from: data)
+        let data = try await dataLoader.validatedData(for: request)
+        return try JSONDecoder.otpDecoder().decode(OTPResponse.self, from: data)
     }
 
     /// Builds a URL for the given endpoint
@@ -109,13 +95,7 @@ public actor RestAPIService: APIService {
     /// - Parameter url: The base URL to normalize
     /// - Returns: Normalized URL with router path included
     private static func normalizeBaseURL(_ url: URL) -> URL {
-        let path = url.path()
-
-        // Check if the path already ends with /routers/<something>
-        let routerPattern = #/routers/[^/]+/?$/#
-        let hasRouterPath = path.contains(routerPattern)
-
-        if hasRouterPath {
+        if url.hasOTPRouterPath {
             return url
         } else {
             return url.appending(path: "routers/default")

--- a/OTPKit/Tests/Fixtures/graphql_plan_routing_error.json
+++ b/OTPKit/Tests/Fixtures/graphql_plan_routing_error.json
@@ -1,0 +1,26 @@
+{
+  "data": {
+    "plan": {
+      "date": 1785340800000,
+      "from": {
+        "name": "Origin",
+        "lon": -80.0,
+        "lat": 25.0,
+        "vertexType": "NORMAL"
+      },
+      "to": {
+        "name": "Destination",
+        "lon": -122.3493,
+        "lat": 47.6205,
+        "vertexType": "NORMAL"
+      },
+      "routingErrors": [
+        {
+          "code": "OUTSIDE_BOUNDS",
+          "description": "Trip is not possible. You might be trying to plan a trip outside the map data boundary."
+        }
+      ],
+      "itineraries": []
+    }
+  }
+}

--- a/OTPKit/Tests/Fixtures/graphql_plan_success.json
+++ b/OTPKit/Tests/Fixtures/graphql_plan_success.json
@@ -1,0 +1,664 @@
+{
+  "data": {
+    "plan": {
+      "date": 1785340800000,
+      "from": {
+        "name": "Origin",
+        "lon": -122.3331,
+        "lat": 47.6097,
+        "vertexType": "NORMAL"
+      },
+      "to": {
+        "name": "Destination",
+        "lon": -122.3493,
+        "lat": 47.6205,
+        "vertexType": "NORMAL"
+      },
+      "routingErrors": [],
+      "itineraries": [
+        {
+          "duration": 775,
+          "startTime": 1785341233000,
+          "endTime": 1785342008000,
+          "walkTime": 595,
+          "waitingTime": 0,
+          "walkDistance": 626.6,
+          "elevationLost": 0.0,
+          "elevationGained": 0.0,
+          "numberOfTransfers": 0,
+          "legs": [
+            {
+              "startTime": 1785341233000,
+              "endTime": 1785341700000,
+              "mode": "WALK",
+              "route": null,
+              "from": {
+                "name": "Origin",
+                "lon": -122.3331,
+                "lat": 47.6097,
+                "vertexType": "NORMAL",
+                "stop": null
+              },
+              "to": {
+                "name": "Westlake Center",
+                "lon": -122.33696,
+                "lat": 47.612046,
+                "vertexType": "TRANSIT",
+                "stop": {
+                  "gtfsId": "96:WL",
+                  "code": null
+                }
+              },
+              "legGeometry": {
+                "points": "owqaHbetiVEBDP@@eA~@CDAAININA@AAC?E@y@r@YVc@^QPONCBAD?FEBGFIJA@J\\Tp@`@rABFABWVoAhAw@r@@B@FSPQVBJ@BIHSP]Z??",
+                "length": 43
+              },
+              "distance": 475.97,
+              "transitLeg": false,
+              "duration": 467.0,
+              "realTime": false,
+              "headsign": null,
+              "intermediatePlaces": null,
+              "steps": [
+                {
+                  "distance": 60.61,
+                  "streetName": "6th Avenue",
+                  "relativeDirection": "DEPART",
+                  "lon": -122.3331305,
+                  "lat": 47.6096872
+                },
+                {
+                  "distance": 135.05,
+                  "streetName": "6th Avenue",
+                  "relativeDirection": "UTURN_RIGHT",
+                  "lon": -122.3337668,
+                  "lat": 47.6101666
+                },
+                {
+                  "distance": 17.78,
+                  "streetName": "6th Avenue",
+                  "relativeDirection": "RIGHT",
+                  "lon": -122.3345615,
+                  "lat": 47.6110276
+                },
+                {
+                  "distance": 72.9,
+                  "streetName": "Pike Street",
+                  "relativeDirection": "LEFT",
+                  "lon": -122.3346944,
+                  "lat": 47.6111598
+                },
+                {
+                  "distance": 5.16,
+                  "streetName": "5th Avenue",
+                  "relativeDirection": "SLIGHTLY_RIGHT",
+                  "lon": -122.3355192,
+                  "lat": 47.6108124
+                },
+                {
+                  "distance": 105.38,
+                  "streetName": "5th Avenue",
+                  "relativeDirection": "RIGHT",
+                  "lon": -122.3355799,
+                  "lat": 47.6108046
+                },
+                {
+                  "distance": 2.22,
+                  "streetName": "Pine Street",
+                  "relativeDirection": "LEFT",
+                  "lon": -122.3363222,
+                  "lat": 47.6116094
+                },
+                {
+                  "distance": 35.06,
+                  "streetName": "path",
+                  "relativeDirection": "CONTINUE",
+                  "lon": -122.336347,
+                  "lat": 47.6115985
+                },
+                {
+                  "distance": 1.83,
+                  "streetName": "Pine Street",
+                  "relativeDirection": "CONTINUE",
+                  "lon": -122.3366545,
+                  "lat": 47.6117507
+                },
+                {
+                  "distance": 40.0,
+                  "streetName": "5th Avenue",
+                  "relativeDirection": "RIGHT",
+                  "lon": -122.3366751,
+                  "lat": 47.6117418
+                }
+              ]
+            },
+            {
+              "startTime": 1785341700000,
+              "endTime": 1785341880000,
+              "mode": "MONORAIL",
+              "route": {
+                "shortName": "Monorail",
+                "type": 12,
+                "color": null,
+                "textColor": null,
+                "agency": {
+                  "name": "Seattle Center Monorail"
+                }
+              },
+              "from": {
+                "name": "Westlake Center",
+                "lon": -122.33696,
+                "lat": 47.612046,
+                "vertexType": "TRANSIT",
+                "stop": {
+                  "gtfsId": "96:WL",
+                  "code": null
+                }
+              },
+              "to": {
+                "name": "Seattle Center",
+                "lon": -122.349955,
+                "lat": 47.621263,
+                "vertexType": "TRANSIT",
+                "stop": {
+                  "gtfsId": "96:SC",
+                  "code": null
+                }
+              },
+              "legGeometry": {
+                "points": "gfraH~|tiVuBhBe@j@y@|A_EdI}Pl]gGzLYf@QTg@f@]TcA\\[DuBBaBAy@Da@L]TYf@Oh@Kt@ANB~F",
+                "length": 23
+              },
+              "distance": 1507.0,
+              "transitLeg": true,
+              "duration": 180.0,
+              "realTime": false,
+              "headsign": "Seattle Center",
+              "intermediatePlaces": [],
+              "steps": []
+            },
+            {
+              "startTime": 1785341880000,
+              "endTime": 1785342008000,
+              "mode": "WALK",
+              "route": null,
+              "from": {
+                "name": "Seattle Center",
+                "lon": -122.349955,
+                "lat": 47.621263,
+                "vertexType": "TRANSIT",
+                "stop": {
+                  "gtfsId": "96:SC",
+                  "code": null
+                }
+              },
+              "to": {
+                "name": "Destination",
+                "lon": -122.3493,
+                "lat": 47.6205,
+                "vertexType": "NORMAL",
+                "stop": null
+              },
+              "legGeometry": {
+                "points": "{_taHfnwiV??XFJC@C@m@X?BA?I?KNKRCXADBDBF?DAFCDEBEBI@I@I?IAIAC",
+                "length": 26
+              },
+              "distance": 150.63,
+              "transitLeg": false,
+              "duration": 128.0,
+              "realTime": false,
+              "headsign": null,
+              "intermediatePlaces": null,
+              "steps": [
+                {
+                  "distance": 15.06,
+                  "streetName": "Seattle Monorail Concourse",
+                  "relativeDirection": "DEPART",
+                  "lon": -122.349955,
+                  "lat": 47.621263
+                },
+                {
+                  "distance": 135.56,
+                  "streetName": "path",
+                  "relativeDirection": "LEFT",
+                  "lon": -122.3499937,
+                  "lat": 47.6211301
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "duration": 1104,
+          "startTime": 1785341432000,
+          "endTime": 1785342536000,
+          "walkTime": 647,
+          "waitingTime": 0,
+          "walkDistance": 748.1,
+          "elevationLost": 0.0,
+          "elevationGained": 0.0,
+          "numberOfTransfers": 0,
+          "legs": [
+            {
+              "startTime": 1785341432000,
+              "endTime": 1785341760000,
+              "mode": "WALK",
+              "route": null,
+              "from": {
+                "name": "Origin",
+                "lon": -122.3331,
+                "lat": 47.6097,
+                "vertexType": "NORMAL",
+                "stop": null
+              },
+              "to": {
+                "name": "3rd Ave & Union St",
+                "lon": -122.3367,
+                "lat": 47.6086884,
+                "vertexType": "TRANSIT",
+                "stop": {
+                  "gtfsId": "kcm:570",
+                  "code": "570"
+                }
+              },
+              "legGeometry": {
+                "points": "owqaHbetiVEBDP@@eA~@CDX|@HVRl@Tp@@ABFBHBLBD?@@DDN~@vCDA@FFX@H@B@B?DBHTt@j@hBFGBD",
+                "length": 31
+              },
+              "distance": 343.94,
+              "transitLeg": false,
+              "duration": 328.0,
+              "realTime": false,
+              "headsign": null,
+              "intermediatePlaces": null,
+              "steps": [
+                {
+                  "distance": 60.61,
+                  "streetName": "6th Avenue",
+                  "relativeDirection": "DEPART",
+                  "lon": -122.3331305,
+                  "lat": 47.6096872
+                },
+                {
+                  "distance": 38.02,
+                  "streetName": "sidewalk",
+                  "relativeDirection": "LEFT",
+                  "lon": -122.3336032,
+                  "lat": 47.6100412
+                },
+                {
+                  "distance": 240.12,
+                  "streetName": "Union Street",
+                  "relativeDirection": "CONTINUE",
+                  "lon": -122.3340342,
+                  "lat": 47.609861
+                },
+                {
+                  "distance": 5.22,
+                  "streetName": "3rd Avenue",
+                  "relativeDirection": "LEFT",
+                  "lon": -122.3367025,
+                  "lat": 47.6087422
+                }
+              ]
+            },
+            {
+              "startTime": 1785341760000,
+              "endTime": 1785342217000,
+              "mode": "BUS",
+              "route": {
+                "shortName": "33",
+                "type": 3,
+                "color": "FDB71A",
+                "textColor": "000000",
+                "agency": {
+                  "name": "Metro Transit"
+                }
+              },
+              "from": {
+                "name": "3rd Ave & Union St",
+                "lon": -122.3367,
+                "lat": 47.6086884,
+                "vertexType": "TRANSIT",
+                "stop": {
+                  "gtfsId": "kcm:570",
+                  "code": "570"
+                }
+              },
+              "to": {
+                "name": "Denny Way & 2nd Ave N",
+                "lon": -122.352615,
+                "lat": 47.61866,
+                "vertexType": "TRANSIT",
+                "stop": {
+                  "gtfsId": "kcm:20829",
+                  "code": "20829"
+                }
+              },
+              "legGeometry": {
+                "points": "aqqaH~{tiVSRgErDwChCm@j@gA`AcA`AIFGFGHKPKTOVKRO`@aB`DkBvDk@jAyCdGeBhDs@xAiAtBkAbCCFEJgBnDoBxD_AlBm@jAmBzDmBxDMb@k@hAIPAD?dF?@",
+                "length": 37
+              },
+              "distance": 1657.0,
+              "transitLeg": true,
+              "duration": 457.0,
+              "realTime": false,
+              "headsign": "E Magnolia",
+              "intermediatePlaces": [
+                {
+                  "name": "3rd Ave & Pine St",
+                  "lon": -122.338951,
+                  "lat": 47.6111374,
+                  "vertexType": "TRANSIT",
+                  "stop": {
+                    "gtfsId": "kcm:590",
+                    "code": "590"
+                  }
+                },
+                {
+                  "name": "3rd Ave & Virginia St",
+                  "lon": -122.341743,
+                  "lat": 47.6129951,
+                  "vertexType": "TRANSIT",
+                  "stop": {
+                    "gtfsId": "kcm:600",
+                    "code": "600"
+                  }
+                },
+                {
+                  "name": "3rd Ave & Bell St",
+                  "lon": -122.345337,
+                  "lat": 47.6151199,
+                  "vertexType": "TRANSIT",
+                  "stop": {
+                    "gtfsId": "kcm:605",
+                    "code": "605"
+                  }
+                },
+                {
+                  "name": "3rd Ave & Vine St",
+                  "lon": -122.34845,
+                  "lat": 47.6169586,
+                  "vertexType": "TRANSIT",
+                  "stop": {
+                    "gtfsId": "kcm:1690",
+                    "code": "1690"
+                  }
+                }
+              ],
+              "steps": []
+            },
+            {
+              "startTime": 1785342217000,
+              "endTime": 1785342536000,
+              "mode": "WALK",
+              "route": null,
+              "from": {
+                "name": "Denny Way & 2nd Ave N",
+                "lon": -122.352615,
+                "lat": 47.61866,
+                "vertexType": "TRANSIT",
+                "stop": {
+                  "gtfsId": "kcm:20829",
+                  "code": "20829"
+                }
+              },
+              "to": {
+                "name": "Destination",
+                "lon": -122.3493,
+                "lat": 47.6205,
+                "vertexType": "NORMAL",
+                "stop": null
+              },
+              "legGeometry": {
+                "points": "sosaHz~wiVA??kBEGCGAG?kE@GBEBCAGAWAKCKCGCEGIGEIEKEGOEQCAGAMAMAICIEEGIKEGEGU?WDWFKBC@?ECKCGAAC?C@AAECIAIC@_@BWE?CAECGKEMAOC?C?IU",
+                "length": 58
+              },
+              "distance": 404.16,
+              "transitLeg": false,
+              "duration": 319.0,
+              "realTime": false,
+              "headsign": null,
+              "intermediatePlaces": null,
+              "steps": [
+                {
+                  "distance": 136.53,
+                  "streetName": "Denny Way",
+                  "relativeDirection": "DEPART",
+                  "lon": -122.352615,
+                  "lat": 47.6186763
+                },
+                {
+                  "distance": 225.08,
+                  "streetName": "path",
+                  "relativeDirection": "CONTINUE",
+                  "lon": -122.3508456,
+                  "lat": 47.6186882
+                },
+                {
+                  "distance": 42.55,
+                  "streetName": "path",
+                  "relativeDirection": "UTURN_LEFT",
+                  "lon": -122.349301,
+                  "lat": 47.6202614
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "duration": 775,
+          "startTime": 1785341833000,
+          "endTime": 1785342608000,
+          "walkTime": 595,
+          "waitingTime": 0,
+          "walkDistance": 626.6,
+          "elevationLost": 0.0,
+          "elevationGained": 0.0,
+          "numberOfTransfers": 0,
+          "legs": [
+            {
+              "startTime": 1785341833000,
+              "endTime": 1785342300000,
+              "mode": "WALK",
+              "route": null,
+              "from": {
+                "name": "Origin",
+                "lon": -122.3331,
+                "lat": 47.6097,
+                "vertexType": "NORMAL",
+                "stop": null
+              },
+              "to": {
+                "name": "Westlake Center",
+                "lon": -122.33696,
+                "lat": 47.612046,
+                "vertexType": "TRANSIT",
+                "stop": {
+                  "gtfsId": "96:WL",
+                  "code": null
+                }
+              },
+              "legGeometry": {
+                "points": "owqaHbetiVEBDP@@eA~@CDAAININA@AAC?E@y@r@YVc@^QPONCBAD?FEBGFIJA@J\\Tp@`@rABFABWVoAhAw@r@@B@FSPQVBJ@BIHSP]Z??",
+                "length": 43
+              },
+              "distance": 475.97,
+              "transitLeg": false,
+              "duration": 467.0,
+              "realTime": false,
+              "headsign": null,
+              "intermediatePlaces": null,
+              "steps": [
+                {
+                  "distance": 60.61,
+                  "streetName": "6th Avenue",
+                  "relativeDirection": "DEPART",
+                  "lon": -122.3331305,
+                  "lat": 47.6096872
+                },
+                {
+                  "distance": 135.05,
+                  "streetName": "6th Avenue",
+                  "relativeDirection": "UTURN_RIGHT",
+                  "lon": -122.3337668,
+                  "lat": 47.6101666
+                },
+                {
+                  "distance": 17.78,
+                  "streetName": "6th Avenue",
+                  "relativeDirection": "RIGHT",
+                  "lon": -122.3345615,
+                  "lat": 47.6110276
+                },
+                {
+                  "distance": 72.9,
+                  "streetName": "Pike Street",
+                  "relativeDirection": "LEFT",
+                  "lon": -122.3346944,
+                  "lat": 47.6111598
+                },
+                {
+                  "distance": 5.16,
+                  "streetName": "5th Avenue",
+                  "relativeDirection": "SLIGHTLY_RIGHT",
+                  "lon": -122.3355192,
+                  "lat": 47.6108124
+                },
+                {
+                  "distance": 105.38,
+                  "streetName": "5th Avenue",
+                  "relativeDirection": "RIGHT",
+                  "lon": -122.3355799,
+                  "lat": 47.6108046
+                },
+                {
+                  "distance": 2.22,
+                  "streetName": "Pine Street",
+                  "relativeDirection": "LEFT",
+                  "lon": -122.3363222,
+                  "lat": 47.6116094
+                },
+                {
+                  "distance": 35.06,
+                  "streetName": "path",
+                  "relativeDirection": "CONTINUE",
+                  "lon": -122.336347,
+                  "lat": 47.6115985
+                },
+                {
+                  "distance": 1.83,
+                  "streetName": "Pine Street",
+                  "relativeDirection": "CONTINUE",
+                  "lon": -122.3366545,
+                  "lat": 47.6117507
+                },
+                {
+                  "distance": 40.0,
+                  "streetName": "5th Avenue",
+                  "relativeDirection": "RIGHT",
+                  "lon": -122.3366751,
+                  "lat": 47.6117418
+                }
+              ]
+            },
+            {
+              "startTime": 1785342300000,
+              "endTime": 1785342480000,
+              "mode": "MONORAIL",
+              "route": {
+                "shortName": "Monorail",
+                "type": 12,
+                "color": null,
+                "textColor": null,
+                "agency": {
+                  "name": "Seattle Center Monorail"
+                }
+              },
+              "from": {
+                "name": "Westlake Center",
+                "lon": -122.33696,
+                "lat": 47.612046,
+                "vertexType": "TRANSIT",
+                "stop": {
+                  "gtfsId": "96:WL",
+                  "code": null
+                }
+              },
+              "to": {
+                "name": "Seattle Center",
+                "lon": -122.349955,
+                "lat": 47.621263,
+                "vertexType": "TRANSIT",
+                "stop": {
+                  "gtfsId": "96:SC",
+                  "code": null
+                }
+              },
+              "legGeometry": {
+                "points": "gfraH~|tiVuBhBe@j@y@|A_EdI}Pl]gGzLYf@QTg@f@]TcA\\[DuBBaBAy@Da@L]TYf@Oh@Kt@ANB~F",
+                "length": 23
+              },
+              "distance": 1507.0,
+              "transitLeg": true,
+              "duration": 180.0,
+              "realTime": false,
+              "headsign": "Seattle Center",
+              "intermediatePlaces": [],
+              "steps": []
+            },
+            {
+              "startTime": 1785342480000,
+              "endTime": 1785342608000,
+              "mode": "WALK",
+              "route": null,
+              "from": {
+                "name": "Seattle Center",
+                "lon": -122.349955,
+                "lat": 47.621263,
+                "vertexType": "TRANSIT",
+                "stop": {
+                  "gtfsId": "96:SC",
+                  "code": null
+                }
+              },
+              "to": {
+                "name": "Destination",
+                "lon": -122.3493,
+                "lat": 47.6205,
+                "vertexType": "NORMAL",
+                "stop": null
+              },
+              "legGeometry": {
+                "points": "{_taHfnwiV??XFJC@C@m@X?BA?I?KNKRCXADBDBF?DAFCDEBEBI@I@I?IAIAC",
+                "length": 26
+              },
+              "distance": 150.63,
+              "transitLeg": false,
+              "duration": 128.0,
+              "realTime": false,
+              "headsign": null,
+              "intermediatePlaces": null,
+              "steps": [
+                {
+                  "distance": 15.06,
+                  "streetName": "Seattle Monorail Concourse",
+                  "relativeDirection": "DEPART",
+                  "lon": -122.349955,
+                  "lat": 47.621263
+                },
+                {
+                  "distance": 135.56,
+                  "streetName": "path",
+                  "relativeDirection": "LEFT",
+                  "lon": -122.3499937,
+                  "lat": 47.6211301
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/OTPKit/Tests/GraphQLAPIServiceTests.swift
+++ b/OTPKit/Tests/GraphQLAPIServiceTests.swift
@@ -80,12 +80,24 @@ class GraphQLAPIServiceTests: OTPTestCase {
         XCTAssertEqual(modes.map { $0["mode"] as? String }, ["TRANSIT", "WALK"])
     }
 
+    func testFetchPlanMapsBikeModeToGraphQLBicycle() async throws {
+        mockDataLoader.mockResponse(data: Fixtures.loadData(file: "graphql_plan_success.json"))
+
+        _ = try await service.fetchPlan(createTripPlanRequest(transportModes: [.bike, .walk]))
+
+        let request = try XCTUnwrap(mockDataLoader.lastRequest)
+        let body = try XCTUnwrap(request.httpBody)
+        let payload = try XCTUnwrap(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+        let variables = try XCTUnwrap(payload["variables"] as? [String: Any])
+        let modes = try XCTUnwrap(variables["transportModes"] as? [[String: Any]])
+        // The GraphQL Mode enum spells it BICYCLE; TransportMode.bike.rawValue ("BIKE") is a REST-only token.
+        XCTAssertEqual(modes.map { $0["mode"] as? String }, ["BICYCLE", "WALK"])
+    }
+
     // MARK: - Response Mapping
 
     func testFetchPlanMapsItineraries() async throws {
-        mockDataLoader.mockResponse(data: Fixtures.loadData(file: "graphql_plan_success.json"))
-
-        let response = try await service.fetchPlan(createTripPlanRequest())
+        let response = try await fetchSuccessPlan()
 
         XCTAssertNil(response.error)
         let plan = try XCTUnwrap(response.plan)
@@ -108,9 +120,7 @@ class GraphQLAPIServiceTests: OTPTestCase {
     }
 
     func testFetchPlanMapsTransitLeg() async throws {
-        mockDataLoader.mockResponse(data: Fixtures.loadData(file: "graphql_plan_success.json"))
-
-        let response = try await service.fetchPlan(createTripPlanRequest())
+        let response = try await fetchSuccessPlan()
 
         let leg = try XCTUnwrap(response.plan?.itineraries[0].legs[1])
         XCTAssertEqual(leg.mode, "MONORAIL")
@@ -131,9 +141,7 @@ class GraphQLAPIServiceTests: OTPTestCase {
     }
 
     func testFetchPlanMapsBusLegWithIntermediateStops() async throws {
-        mockDataLoader.mockResponse(data: Fixtures.loadData(file: "graphql_plan_success.json"))
-
-        let response = try await service.fetchPlan(createTripPlanRequest())
+        let response = try await fetchSuccessPlan()
 
         let leg = try XCTUnwrap(response.plan?.itineraries[1].legs[1])
         XCTAssertEqual(leg.mode, "BUS")
@@ -144,9 +152,7 @@ class GraphQLAPIServiceTests: OTPTestCase {
     }
 
     func testFetchPlanMapsWalkLegSteps() async throws {
-        mockDataLoader.mockResponse(data: Fixtures.loadData(file: "graphql_plan_success.json"))
-
-        let response = try await service.fetchPlan(createTripPlanRequest())
+        let response = try await fetchSuccessPlan()
 
         let leg = try XCTUnwrap(response.plan?.itineraries[0].legs[0])
         XCTAssertEqual(leg.mode, "WALK")
@@ -159,9 +165,7 @@ class GraphQLAPIServiceTests: OTPTestCase {
     }
 
     func testFetchPlanSynthesizesRequestParameters() async throws {
-        mockDataLoader.mockResponse(data: Fixtures.loadData(file: "graphql_plan_success.json"))
-
-        let response = try await service.fetchPlan(createTripPlanRequest())
+        let response = try await fetchSuccessPlan()
 
         let params = response.requestParameters
         XCTAssertEqual(params.fromPlace, "47.6097,-122.3331")
@@ -222,27 +226,23 @@ class GraphQLAPIServiceTests: OTPTestCase {
 // MARK: - Test Helpers
 
 private extension GraphQLAPIServiceTests {
-    func createTripPlanRequest(
-        transportModes: [TransportMode] = [.transit, .walk],
-        maxWalkDistance: Int = 800,
-        wheelchairAccessible: Bool = false,
-        arriveBy: Bool = false
-    ) -> TripPlanRequest {
-        guard let date = DateFormatter.tripDateFormatter.date(from: "05-10-2024"),
-              let time = DateFormatter.tripAPITimeFormatter.date(from: "08:00") else {
-            XCTFail("Failed to parse test dates")
-            fatalError("Test setup failure")
-        }
+    static let testDate = DateFormatter.tripDateFormatter.date(from: "05-10-2024")!
+    static let testTime = DateFormatter.tripAPITimeFormatter.date(from: "08:00")!
 
-        return TripPlanRequest(
+    func createTripPlanRequest(transportModes: [TransportMode] = [.transit, .walk]) -> TripPlanRequest {
+        TestFixtures.makeTripPlanRequest(
             origin: CLLocationCoordinate2D(latitude: 47.6097, longitude: -122.3331),
             destination: CLLocationCoordinate2D(latitude: 47.6205, longitude: -122.3493),
-            date: date,
-            time: time,
+            date: Self.testDate,
+            time: Self.testTime,
             transportModes: transportModes,
-            maxWalkDistance: maxWalkDistance,
-            wheelchairAccessible: wheelchairAccessible,
-            arriveBy: arriveBy
+            maxWalkDistance: 800
         )
+    }
+
+    /// Mocks the captured live-server success fixture and fetches a plan through the service.
+    func fetchSuccessPlan() async throws -> OTPResponse {
+        mockDataLoader.mockResponse(data: Fixtures.loadData(file: "graphql_plan_success.json"))
+        return try await service.fetchPlan(createTripPlanRequest())
     }
 }

--- a/OTPKit/Tests/GraphQLAPIServiceTests.swift
+++ b/OTPKit/Tests/GraphQLAPIServiceTests.swift
@@ -189,6 +189,8 @@ class GraphQLAPIServiceTests: OTPTestCase {
         let error = try XCTUnwrap(response.error)
         XCTAssertEqual(error.messageCode, .outsideBounds)
         XCTAssertTrue(error.message.contains("outside the map data boundary"))
+        // GraphQL routing errors carry no wire id; it must stay absent, not a fabricated sentinel.
+        XCTAssertNil(error.id)
     }
 
     func testFetchPlanMapsUnrecognizedRoutingErrorToUnknown() async throws {
@@ -208,6 +210,7 @@ class GraphQLAPIServiceTests: OTPTestCase {
         let error = try XCTUnwrap(response.error)
         XCTAssertEqual(error.messageCode, .unknown)
         XCTAssertEqual(error.message, "Something new went wrong.")
+        XCTAssertNil(error.id)
     }
 
     func testFetchPlanThrowsOnTopLevelGraphQLError() async throws {

--- a/OTPKit/Tests/GraphQLAPIServiceTests.swift
+++ b/OTPKit/Tests/GraphQLAPIServiceTests.swift
@@ -1,0 +1,248 @@
+/*
+ * Copyright (C) Open Transit Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@testable import OTPKit
+import XCTest
+import CoreLocation
+
+class GraphQLAPIServiceTests: OTPTestCase {
+
+    private var service: GraphQLAPIService!
+    private var mockDataLoader: MockDataLoader!
+
+    override func setUp() {
+        super.setUp()
+        service = buildGraphQLAPIService()
+        mockDataLoader = (service.dataLoader as? MockDataLoader)!
+    }
+
+    // MARK: - Endpoint URL
+
+    func testEndpointURLFromOTPRoot() {
+        let service = buildGraphQLAPIService(baseURLString: "https://sound-transit-otp.ibi-transit.com/otp/")
+        XCTAssertEqual(service.endpointURL.absoluteString, "https://sound-transit-otp.ibi-transit.com/otp/gtfs/v1")
+    }
+
+    func testEndpointURLStripsRoutersPath() {
+        let service = buildGraphQLAPIService(baseURLString: "https://otp.example.com/otp/routers/default/")
+        XCTAssertEqual(service.endpointURL.absoluteString, "https://otp.example.com/otp/gtfs/v1")
+    }
+
+    func testEndpointURLAlreadyPointsAtGraphQL() {
+        let service = buildGraphQLAPIService(baseURLString: "https://otp.example.com/otp/gtfs/v1")
+        XCTAssertEqual(service.endpointURL.absoluteString, "https://otp.example.com/otp/gtfs/v1")
+    }
+
+    // MARK: - Request Building
+
+    func testFetchPlanSendsGraphQLRequest() async throws {
+        mockDataLoader.mockResponse(data: Fixtures.loadData(file: "graphql_plan_success.json"))
+
+        _ = try await service.fetchPlan(createTripPlanRequest())
+
+        let request = try XCTUnwrap(mockDataLoader.lastRequest)
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(request.url?.absoluteString, "https://sound-transit-otp.ibi-transit.com/otp/gtfs/v1")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
+
+        let body = try XCTUnwrap(request.httpBody)
+        let payload = try XCTUnwrap(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+        let query = try XCTUnwrap(payload["query"] as? String)
+        XCTAssertTrue(query.contains("plan("))
+
+        let variables = try XCTUnwrap(payload["variables"] as? [String: Any])
+        let from = try XCTUnwrap(variables["from"] as? [String: Any])
+        XCTAssertEqual(from["lat"] as? Double, 47.6097)
+        XCTAssertEqual(from["lon"] as? Double, -122.3331)
+        let to = try XCTUnwrap(variables["to"] as? [String: Any])
+        XCTAssertEqual(to["lat"] as? Double, 47.6205)
+        XCTAssertEqual(to["lon"] as? Double, -122.3493)
+        XCTAssertEqual(variables["date"] as? String, "05-10-2024")
+        XCTAssertEqual(variables["time"] as? String, "8:00 AM")
+        XCTAssertEqual(variables["arriveBy"] as? Bool, false)
+        XCTAssertEqual(variables["wheelchair"] as? Bool, false)
+        XCTAssertEqual(variables["maxWalkDistance"] as? Double, 800)
+
+        let modes = try XCTUnwrap(variables["transportModes"] as? [[String: Any]])
+        XCTAssertEqual(modes.map { $0["mode"] as? String }, ["TRANSIT", "WALK"])
+    }
+
+    // MARK: - Response Mapping
+
+    func testFetchPlanMapsItineraries() async throws {
+        mockDataLoader.mockResponse(data: Fixtures.loadData(file: "graphql_plan_success.json"))
+
+        let response = try await service.fetchPlan(createTripPlanRequest())
+
+        XCTAssertNil(response.error)
+        let plan = try XCTUnwrap(response.plan)
+        XCTAssertEqual(plan.date, Date(timeIntervalSince1970: 1_785_340_800))
+        XCTAssertEqual(plan.from.name, "Origin")
+        XCTAssertEqual(plan.to.name, "Destination")
+        XCTAssertEqual(plan.itineraries.count, 3)
+
+        let itinerary = plan.itineraries[0]
+        XCTAssertEqual(itinerary.duration, 775)
+        XCTAssertEqual(itinerary.startTime, Date(timeIntervalSince1970: 1_785_341_233))
+        XCTAssertEqual(itinerary.endTime, Date(timeIntervalSince1970: 1_785_342_008))
+        XCTAssertEqual(itinerary.walkTime, 595)
+        XCTAssertEqual(itinerary.waitingTime, 0)
+        XCTAssertEqual(itinerary.transitTime, 180)
+        XCTAssertEqual(itinerary.walkDistance, 626.6, accuracy: 0.01)
+        XCTAssertEqual(itinerary.transfers, 0)
+        XCTAssertFalse(itinerary.walkLimitExceeded)
+        XCTAssertEqual(itinerary.legs.count, 3)
+    }
+
+    func testFetchPlanMapsTransitLeg() async throws {
+        mockDataLoader.mockResponse(data: Fixtures.loadData(file: "graphql_plan_success.json"))
+
+        let response = try await service.fetchPlan(createTripPlanRequest())
+
+        let leg = try XCTUnwrap(response.plan?.itineraries[0].legs[1])
+        XCTAssertEqual(leg.mode, "MONORAIL")
+        XCTAssertEqual(leg.route, "Monorail")
+        XCTAssertEqual(leg.agencyName, "Seattle Center Monorail")
+        // GTFS extended route type 12 has no RouteType case; it must degrade to nil, not fail decoding.
+        XCTAssertNil(leg.routeType)
+        XCTAssertEqual(leg.transitLeg, true)
+        XCTAssertEqual(leg.headsign, "Seattle Center")
+        XCTAssertEqual(leg.duration, 180)
+        XCTAssertEqual(leg.distance, 1507.0)
+        XCTAssertEqual(leg.startTime, Date(timeIntervalSince1970: 1_785_341_700))
+        XCTAssertEqual(leg.from.name, "Westlake Center")
+        XCTAssertEqual(leg.from.stopId, "96:WL")
+        XCTAssertEqual(leg.from.vertexType, "TRANSIT")
+        XCTAssertEqual(leg.to.stopId, "96:SC")
+        XCTAssertFalse(leg.legGeometry.points.isEmpty)
+    }
+
+    func testFetchPlanMapsBusLegWithIntermediateStops() async throws {
+        mockDataLoader.mockResponse(data: Fixtures.loadData(file: "graphql_plan_success.json"))
+
+        let response = try await service.fetchPlan(createTripPlanRequest())
+
+        let leg = try XCTUnwrap(response.plan?.itineraries[1].legs[1])
+        XCTAssertEqual(leg.mode, "BUS")
+        XCTAssertEqual(leg.route, "33")
+        XCTAssertEqual(leg.routeType, .bus)
+        XCTAssertEqual(leg.intermediateStops?.count, 4)
+        XCTAssertNotNil(leg.intermediateStops?.first?.stopId)
+    }
+
+    func testFetchPlanMapsWalkLegSteps() async throws {
+        mockDataLoader.mockResponse(data: Fixtures.loadData(file: "graphql_plan_success.json"))
+
+        let response = try await service.fetchPlan(createTripPlanRequest())
+
+        let leg = try XCTUnwrap(response.plan?.itineraries[0].legs[0])
+        XCTAssertEqual(leg.mode, "WALK")
+        XCTAssertTrue(leg.walkMode)
+        XCTAssertNil(leg.route)
+        let step = try XCTUnwrap(leg.steps?.first)
+        XCTAssertEqual(step.streetName, "6th Avenue")
+        XCTAssertEqual(step.relativeDirection, "DEPART")
+        XCTAssertEqual(step.distance, 60.61, accuracy: 0.01)
+    }
+
+    func testFetchPlanSynthesizesRequestParameters() async throws {
+        mockDataLoader.mockResponse(data: Fixtures.loadData(file: "graphql_plan_success.json"))
+
+        let response = try await service.fetchPlan(createTripPlanRequest())
+
+        let params = response.requestParameters
+        XCTAssertEqual(params.fromPlace, "47.6097,-122.3331")
+        XCTAssertEqual(params.toPlace, "47.6205,-122.3493")
+        XCTAssertEqual(params.date, "05-10-2024")
+        XCTAssertEqual(params.time, "8:00 AM")
+        XCTAssertEqual(params.mode, "TRANSIT,WALK")
+        XCTAssertEqual(params.arriveBy, "false")
+        XCTAssertEqual(params.maxWalkDistance, "800")
+        XCTAssertEqual(params.wheelchair, "false")
+    }
+
+    // MARK: - Error Handling
+
+    func testFetchPlanMapsRoutingErrors() async throws {
+        mockDataLoader.mockResponse(data: Fixtures.loadData(file: "graphql_plan_routing_error.json"))
+
+        let response = try await service.fetchPlan(createTripPlanRequest())
+
+        XCTAssertEqual(response.plan?.itineraries.count, 0)
+        let error = try XCTUnwrap(response.error)
+        XCTAssertEqual(error.messageCode, .outsideBounds)
+        XCTAssertTrue(error.message.contains("outside the map data boundary"))
+    }
+
+    func testFetchPlanThrowsOnTopLevelGraphQLError() async throws {
+        let errorJSON = """
+        {"errors":[{"message":"Validation error (FieldUndefined@[plan]) : Field 'plan' is undefined"}]}
+        """
+        mockDataLoader.mockResponse(data: Data(errorJSON.utf8))
+
+        do {
+            _ = try await service.fetchPlan(createTripPlanRequest())
+            XCTFail("Expected fetchPlan to throw")
+        } catch let error as OTPKitError {
+            guard case .apiError(let message, _) = error else {
+                return XCTFail("Expected apiError, got \(error)")
+            }
+            XCTAssertTrue(message.contains("Validation error"))
+        }
+    }
+
+    func testFetchPlanThrowsOnHTTPError() async throws {
+        mockDataLoader.mockResponse(data: Data("{}".utf8), statusCode: 500)
+
+        do {
+            _ = try await service.fetchPlan(createTripPlanRequest())
+            XCTFail("Expected fetchPlan to throw")
+        } catch let error as OTPKitError {
+            guard case .apiError(_, let statusCode) = error else {
+                return XCTFail("Expected apiError, got \(error)")
+            }
+            XCTAssertEqual(statusCode, 500)
+        }
+    }
+}
+
+// MARK: - Test Helpers
+
+private extension GraphQLAPIServiceTests {
+    func createTripPlanRequest(
+        transportModes: [TransportMode] = [.transit, .walk],
+        maxWalkDistance: Int = 800,
+        wheelchairAccessible: Bool = false,
+        arriveBy: Bool = false
+    ) -> TripPlanRequest {
+        guard let date = DateFormatter.tripDateFormatter.date(from: "05-10-2024"),
+              let time = DateFormatter.tripAPITimeFormatter.date(from: "08:00") else {
+            XCTFail("Failed to parse test dates")
+            fatalError("Test setup failure")
+        }
+
+        return TripPlanRequest(
+            origin: CLLocationCoordinate2D(latitude: 47.6097, longitude: -122.3331),
+            destination: CLLocationCoordinate2D(latitude: 47.6205, longitude: -122.3493),
+            date: date,
+            time: time,
+            transportModes: transportModes,
+            maxWalkDistance: maxWalkDistance,
+            wheelchairAccessible: wheelchairAccessible,
+            arriveBy: arriveBy
+        )
+    }
+}

--- a/OTPKit/Tests/GraphQLAPIServiceTests.swift
+++ b/OTPKit/Tests/GraphQLAPIServiceTests.swift
@@ -191,6 +191,25 @@ class GraphQLAPIServiceTests: OTPTestCase {
         XCTAssertTrue(error.message.contains("outside the map data boundary"))
     }
 
+    func testFetchPlanMapsUnrecognizedRoutingErrorToUnknown() async throws {
+        let json = """
+        {"data":{"plan":{
+            "date":1785340800000,
+            "from":{"name":"Origin","lon":-80.0,"lat":25.0,"vertexType":"NORMAL"},
+            "to":{"name":"Destination","lon":-122.3493,"lat":47.6205,"vertexType":"NORMAL"},
+            "routingErrors":[{"code":"SOME_FUTURE_CODE","description":"Something new went wrong."}],
+            "itineraries":[]
+        }}}
+        """
+        mockDataLoader.mockResponse(data: Data(json.utf8))
+
+        let response = try await service.fetchPlan(createTripPlanRequest())
+
+        let error = try XCTUnwrap(response.error)
+        XCTAssertEqual(error.messageCode, .unknown)
+        XCTAssertEqual(error.message, "Something new went wrong.")
+    }
+
     func testFetchPlanThrowsOnTopLevelGraphQLError() async throws {
         let errorJSON = """
         {"errors":[{"message":"Validation error (FieldUndefined@[plan]) : Field 'plan' is undefined"}]}

--- a/OTPKit/Tests/Helpers/OTPTestCase.swift
+++ b/OTPKit/Tests/Helpers/OTPTestCase.swift
@@ -47,4 +47,11 @@ public class OTPTestCase: XCTestCase {
         let baseURL = URL(string: baseURLString)!
         return RestAPIService(baseURL: baseURL, dataLoader: buildMockDataLoader())
     }
+
+    func buildGraphQLAPIService(
+        baseURLString: String = "https://sound-transit-otp.ibi-transit.com/otp/"
+    ) -> GraphQLAPIService {
+        let baseURL = URL(string: baseURLString)!
+        return GraphQLAPIService(baseURL: baseURL, dataLoader: buildMockDataLoader())
+    }
 }

--- a/docs/superpowers/specs/2026-07-28-graphql-api-service-design.md
+++ b/docs/superpowers/specs/2026-07-28-graphql-api-service-design.md
@@ -1,0 +1,72 @@
+# OTP 2.x GraphQL Support — Design
+
+**Date:** 2026-07-28
+**Goal:** OTPKit works against both OTP 1.x (REST) and OTP 2.x (GraphQL) servers, side by side. No feature expansion — the GraphQL path supports exactly what the REST path supports today.
+
+## Background
+
+OTPKit already isolates networking behind the `APIService` protocol (`fetchPlan(_:) async throws -> OTPResponse`), which was explicitly designed for plugin backends. `RestAPIService` is the only implementation. OTP 2.x servers expose the GTFS GraphQL API at `<server>/otp/gtfs/v1`.
+
+Verified against the target server (`https://sound-transit-otp.ibi-transit.com/otp/`, OTP 2.10.0-SNAPSHOT):
+
+- The GraphQL `plan` query works and returns a shape nearly identical to the OTP 1.x REST response: itineraries/legs with epoch-millisecond timestamps, `legGeometry.points` polylines, `intermediatePlaces`, `steps`.
+- It accepts the same wire formats OTPKit already emits for REST (`date: "MM-dd-yyyy"`, `time: "h:mm a"`), plus `maxWalkDistance`, `arriveBy`, `wheelchair`, and `transportModes`.
+- Routing failures come back as `routingErrors` (codes like `OUTSIDE_BOUNDS`, `NO_TRANSIT_CONNECTION`) instead of the REST `error` object.
+- Nested objects differ from REST: route info lives in `route { shortName type color textColor agency { name } }` and stop IDs in `from.stop { gtfsId code }`.
+
+## Approaches considered
+
+1. **Hand-rolled query + internal Codable DTOs, mapped to existing public models (chosen).** One static GraphQL document, a `variables` dictionary, a small internal DTO tree, and a mapping layer that produces the same `OTPResponse` the REST service produces. No new dependencies; the rest of the app is untouched.
+2. **Apollo iOS with codegen.** Type-safe, but adds a heavyweight dependency and codegen toolchain for a single query. Rejected as overkill.
+3. **Decode GraphQL JSON directly into the existing public models.** The nesting differences (route/agency/stop) would force custom decoding logic into public model types serving two wire formats at once. Rejected as fragile.
+
+Query choice: the legacy `plan` query rather than `planConnection`. `plan` maps 1:1 onto OTPKit's existing models and exists in every OTP 2.x release (verified working on 2.10). `planConnection` is the long-term replacement but has a substantially different shape (cursor connections, `OffsetDateTime` strings, `LegTime` objects) — migrating to it is future work and is contained entirely within `GraphQLAPIService` when it happens.
+
+## Design
+
+### New: `GraphQLAPIService` (OTPKit/Sources/OTPKit/Network/GraphQLAPIService.swift)
+
+A `public actor GraphQLAPIService: APIService`, mirroring `RestAPIService`:
+
+- `init(baseURL: URL, dataLoader: URLDataLoader = URLSession.shared)`
+- Base URL normalization: strip a trailing `routers/<id>` segment if present (so REST-style URLs still work), then append `gtfs/v1` unless the path already ends with it. `https://…/otp/` → `https://…/otp/gtfs/v1`.
+- `fetchPlan(_ request: TripPlanRequest)` POSTs `{"query": …, "variables": …}` with `Content-Type: application/json`, using the same `URLDataLoader` abstraction and the existing wire-format date/time formatters.
+- Non-200 responses throw `OTPKitError.apiError`, same as REST. Top-level GraphQL `errors` throw `OTPKitError.apiError` with the first error message.
+
+### New: internal wire DTOs (OTPKit/Sources/OTPKit/Network/GraphQLPlanResponse.swift)
+
+Internal `Decodable` structs matching the GraphQL response (`plan.itineraries[].legs[].route.agency` etc.), decoded with `.millisecondsSince1970` dates, then mapped to the existing public models:
+
+| Public model field | GraphQL source |
+|---|---|
+| `Itinerary.transitTime` | computed: `max(0, duration - walkTime - waitingTime)` |
+| `Itinerary.transfers` | `numberOfTransfers` |
+| `Itinerary.walkLimitExceeded` | constant `false` (OTP 2.x removed the hard limit) |
+| `Leg.route` / `routeType` / `routeColor` / `routeTextColor` / `agencyName` | `route.shortName` / `route.type` / `route.color` / `route.textColor` / `route.agency.name` |
+| `Place.stopId` / `stopCode` | `stop.gtfsId` / `stop.code` |
+| `Leg.intermediateStops` | `intermediatePlaces` |
+| `OTPResponse.requestParameters` | synthesized from the outgoing `TripPlanRequest` (same strings REST would send) |
+| `OTPResponse.error` | first `routingError`, only when no itineraries came back |
+
+Routing-error code mapping (default `.unknown`): `OUTSIDE_BOUNDS → .outsideBounds`, `NO_TRANSIT_CONNECTION → .pathNotFound`, `NO_TRANSIT_CONNECTION_IN_SEARCH_WINDOW`/`OUTSIDE_SERVICE_PERIOD → .noTransitTimes`, `LOCATION_NOT_FOUND`/`NO_STOPS_IN_RANGE → .locationNotAccessible`, `WALKING_BETTER_THAN_TRANSIT` is ignored (not a failure).
+
+`Leg.streetNames` and `Leg.pathway` have no GraphQL equivalent and are `nil` (both already optional and unused by the UI).
+
+### Demo app
+
+`OTPRegionInfo` gains an `apiType` field (`rest` | `graphQL`, defaulting to `rest` when absent so persisted regions still decode). The onboarding list adds "Seattle (OTP 2.x GraphQL)" pointing at `https://sound-transit-otp.ibi-transit.com/otp/`. `OTPDemoViewController.apiService` becomes `APIService` and is constructed per the region's `apiType`.
+
+### Error handling
+
+- Transport/HTTP failures: `OTPKitError.apiError` (unchanged behavior).
+- GraphQL validation errors (top-level `errors` array): `OTPKitError.apiError` with the server's message.
+- Routing errors: surfaced through the existing `OTPResponse.error` → `ErrorResponseCode.displayMessage` path, so `TripPlannerViewModel` needs no changes.
+
+### Testing
+
+XCTest in the package test target, mirroring `RestAPIServiceTests`:
+
+- Fixtures captured from the live Sound Transit server: success response and routing-error response.
+- Request-building tests: endpoint URL normalization (all three input shapes), POST body contains expected variables (coordinates, modes, arriveBy, wheelchair, maxWalkDistance, date/time strings).
+- Decoding/mapping tests: itinerary counts, timestamps, leg route/agency/stop mapping, transitTime computation, routing-error → `ErrorResponse` mapping, top-level GraphQL error → thrown `OTPKitError`.
+- Manual end-to-end verification against the live server via the demo app.


### PR DESCRIPTION
## Summary

- Adds `GraphQLAPIService`, an actor implementing the existing `APIService` protocol against the OTP 2.x GTFS GraphQL API (`<server>/otp/gtfs/v1`), using the `plan` query and mapping responses onto the same public models the REST path uses — so OTP 1.x and 2.x servers work interchangeably with zero changes to the ViewModel/UI layers.
- Routing failures (`routingErrors`) map onto the existing `ErrorResponse`/`ErrorResponseCode` path (with logging for unrecognized codes); top-level GraphQL errors throw `OTPKitError.apiError`. `TransportMode` values are explicitly translated to the GraphQL `Mode` vocabulary (`.bike` → `BICYCLE`; the REST token `BIKE` fails GraphQL enum validation — verified against the live server).
- Shared wire plumbing (HTTP 200 validation, epoch-millis JSON decoder, OTP `routers/<id>` URL handling) is extracted into `APIServiceSupport.swift` and used by both services. The demo app's regions now declare an API type, with a new "Seattle (OTP 2.x GraphQL)" region backed by `https://sound-transit-otp.ibi-transit.com/otp/`.

## Test plan

- [x] 13 new `GraphQLAPIServiceTests` (fixtures captured from the live Sound Transit OTP 2.10 server): endpoint URL normalization ×3, request-body construction, bike→BICYCLE mode mapping, itinerary/leg/place/step mapping (incl. GTFS extended route type 12 degrading to nil `RouteType`, intermediate stops, computed `transitTime`), synthesized `requestParameters`, routing-error mapping, unknown-code fallback, top-level GraphQL error, HTTP error.
- [x] Full OTPKit test suite passes; SwiftLint 0 violations.
- [x] Live end-to-end in the iOS simulator: fresh install → onboarding with "Seattle (OTP 2.x GraphQL)" selected (persisted defaults confirmed `apiType: graphQL` + sound-transit URL) → planned Current Location → Space Needle → 3 itineraries rendered (walk → Seattle Center Monorail → walk), matching the server's routing.
- [x] Live-server probes: `plan` query with REST-style date/time wire formats, `maxWalkDistance`, BICYCLE vs BIKE validation, and `OUTSIDE_BOUNDS` routing-error responses.

## Review notes

- The legacy `plan` query is used rather than `planConnection` because it maps 1:1 onto the existing models and exists in every OTP 2.x release; migrating to `planConnection` later is contained entirely within `GraphQLAPIService`. Design doc: `docs/superpowers/specs/2026-07-28-graphql-api-service-design.md`.
- Pre-existing, unrelated to this change: the demo app crashes at launch on the iOS 27.0 beta simulator (`__UIApplicationEvaluateRuntimeIssueForNoSceneLifecycleAdoption`) because it uses AppDelegate-only lifecycle with no scene manifest. End-to-end verification was done on iOS 26.3. Worth a follow-up issue for UIScene adoption.
- `GraphQLAPIService` keeps REST parity choices: it's an actor with no mutable state (matches `RestAPIService`), exposes `baseURL`, and synthesizes REST-style `requestParameters` so `OTPResponse` stays uniform across backends.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/OneBusAway/codesmith/otpkit/pr/150"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787869859&installation_model_id=429412&pr_number=150&repository=OneBusAway%2Fotpkit&return_to=https%3A%2F%2Fgithub.com%2FOneBusAway%2Fotpkit%2Fpull%2F150&signature=50641f85a2a05937d54dea9acdd6cbff1b3fdba001c16c5481b628be30a32958"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OTP 2.x GraphQL trip-planning support alongside the existing REST API.
  * Updated demo region onboarding to support selecting a GraphQL-backed Seattle region.
  * Mapped GraphQL plans into the existing itinerary, transit, step, and routing-error response formats.
* **Bug Fixes**
  * Improved REST network request validation and decoding behavior.
* **Documentation**
  * Clarified that itinerary timing values are measured in seconds.
  * Updated API support documentation to reflect GraphQL implementation.
* **Tests**
  * Added GraphQL request/response, URL handling, and error-handling coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->