### PR TITLE
Adopt UIScene lifecycle to fix demo app launch crash on iOS 27

### DIFF
--- a/Demo/OTPKitDemo-Info.plist
+++ b/Demo/OTPKitDemo-Info.plist
@@ -26,5 +26,26 @@
 		<string>zh-Hans</string>
 		<string>zh-Hant</string>
 	</array>
+	<!--
+		iOS 27 requires UIScene lifecycle adoption; apps built with the iOS 27 SDK
+		that only use the UIApplicationDelegate lifecycle crash at launch.
+	-->
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/Demo/OTPKitDemo.xcodeproj/project.pbxproj
+++ b/Demo/OTPKitDemo.xcodeproj/project.pbxproj
@@ -338,8 +338,6 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = OTPKitDemo-Info.plist;
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "Help you find your location on the map to plan a trip.";
-				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
-				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphoneos*]" = YES;
@@ -379,8 +377,6 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = OTPKitDemo-Info.plist;
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "Help you find your location on the map to plan a trip.";
-				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
-				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphoneos*]" = YES;

--- a/Demo/OTPKitDemo/AppDelegate.swift
+++ b/Demo/OTPKitDemo/AppDelegate.swift
@@ -5,56 +5,9 @@
 //  Created by Aaron Brethorst on 10/30/25.
 //
 
-import Foundation
 import UIKit
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
-
-    var window: UIWindow?
-
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        window = UIWindow(frame: UIScreen.main.bounds)
-        window?.backgroundColor = .systemBackground
-
-        // Check if onboarding has been completed
-        let hasCompletedOnboarding = UserDefaults.standard.bool(forKey: "hasCompletedOnboarding")
-
-        print("SceneDelegate - Setting up window")
-        print("Has completed onboarding: \(hasCompletedOnboarding)")
-
-        if hasCompletedOnboarding,
-           let serverURL = UserDefaults.standard.url(forKey: "otpServerURL"),
-           let regionData = UserDefaults.standard.data(forKey: "selectedRegion"),
-           let region = try? JSONDecoder().decode(OTPRegionInfo.self, from: regionData) {
-            // Show main OTP view controller
-            let mainViewController = OTPDemoViewController(serverURL: serverURL, regionInfo: region)
-            let navigationController = UINavigationController(rootViewController: mainViewController)
-            window?.rootViewController = navigationController
-        } else {
-            // Show onboarding
-            print("Showing onboarding screen")
-            let onboardingVC = OnboardingViewController()
-            onboardingVC.onboardingCompleteHandler = { [weak self] serverURL, regionInfo in
-                self?.showMainViewController(serverURL: serverURL, regionInfo: regionInfo)
-            }
-            window?.rootViewController = onboardingVC
-        }
-
-        window?.makeKeyAndVisible()
-        print("Window is key and visible")
-
-        return true
-    }
-
-    private func showMainViewController(serverURL: URL, regionInfo: OTPRegionInfo) {
-        let mainViewController = OTPDemoViewController(serverURL: serverURL, regionInfo: regionInfo)
-        let navigationController = UINavigationController(rootViewController: mainViewController)
-
-        if let window = window {
-            UIView.transition(with: window, duration: 0.3, options: .transitionCrossDissolve, animations: {
-                window.rootViewController = navigationController
-            })
-        }
-    }
+    // Window and root view controller setup lives in SceneDelegate.
 }

--- a/Demo/OTPKitDemo/SceneDelegate.swift
+++ b/Demo/OTPKitDemo/SceneDelegate.swift
@@ -1,0 +1,58 @@
+//
+//  SceneDelegate.swift
+//  OTPKitDemo
+//
+//  Created by Aaron Brethorst on 7/28/26.
+//
+
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    var window: UIWindow?
+
+    func scene(
+        _ scene: UIScene,
+        willConnectTo session: UISceneSession,
+        options connectionOptions: UIScene.ConnectionOptions
+    ) {
+        guard let windowScene = scene as? UIWindowScene else { return }
+
+        let window = UIWindow(windowScene: windowScene)
+        window.backgroundColor = .systemBackground
+
+        // Check if onboarding has been completed
+        let hasCompletedOnboarding = UserDefaults.standard.bool(forKey: "hasCompletedOnboarding")
+
+        if hasCompletedOnboarding,
+           let serverURL = UserDefaults.standard.url(forKey: "otpServerURL"),
+           let regionData = UserDefaults.standard.data(forKey: "selectedRegion"),
+           let region = try? JSONDecoder().decode(OTPRegionInfo.self, from: regionData) {
+            // Show main OTP view controller
+            window.rootViewController = makeMainViewController(serverURL: serverURL, regionInfo: region)
+        } else {
+            // Show onboarding
+            let onboardingViewController = OnboardingViewController()
+            onboardingViewController.onboardingCompleteHandler = { [weak self] serverURL, regionInfo in
+                self?.showMainViewController(serverURL: serverURL, regionInfo: regionInfo)
+            }
+            window.rootViewController = onboardingViewController
+        }
+
+        window.makeKeyAndVisible()
+        self.window = window
+    }
+
+    private func makeMainViewController(serverURL: URL, regionInfo: OTPRegionInfo) -> UIViewController {
+        UINavigationController(rootViewController: OTPDemoViewController(serverURL: serverURL, regionInfo: regionInfo))
+    }
+
+    private func showMainViewController(serverURL: URL, regionInfo: OTPRegionInfo) {
+        guard let window else { return }
+
+        let mainViewController = makeMainViewController(serverURL: serverURL, regionInfo: regionInfo)
+        UIView.transition(with: window, duration: 0.3, options: .transitionCrossDissolve) {
+            window.rootViewController = mainViewController
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes an immediate launch crash of OTPKitDemo on iOS 27 simulators/devices: builds with the iOS 27 SDK enforce UIScene lifecycle adoption, and the demo crashed with `EXC_BREAKPOINT` in `__UIApplicationEvaluateRuntimeIssueForNoSceneLifecycleAdoption` because it created its `UIWindow` in the app delegate with no scene delegate.
- Adds a `SceneDelegate` that owns the window and root view controller selection (onboarding vs. main trip planner), using `UIWindow(windowScene:)`; `AppDelegate` is slimmed to a bare `UIApplicationDelegate`.
- Declares a static `UIApplicationSceneManifest` in `OTPKitDemo-Info.plist` and removes the `INFOPLIST_KEY_UIApplicationSceneManifest_Generation` build settings so the manifest has a single source of truth (the generated one had no delegate class and would conflict with the hand-authored key).

## Test plan
- [x] Reproduced the pre-fix crash on an iOS 27.0 simulator (iPhone 17 Pro, Xcode 27.0 beta): `EXC_BREAKPOINT` in `__UIApplicationEvaluateRuntimeIssueForNoSceneLifecycleAdoption` at launch.
- [x] Post-fix, verified on the same simulator: fresh install shows onboarding; tapping Continue cross-dissolves to the trip planner (exercises the relocated `showMainViewController` path); location-permission prompt handled; map renders.
- [x] Terminate + relaunch goes straight to the trip planner (exercises the `hasCompletedOnboarding` restore branch in `SceneDelegate`); no new crash reports across any run.
- [x] `xcodebuild test -scheme OTPKit` passes (iPhone 17 Pro Max, iOS 26.3.1).
- [x] SwiftLint clean on the changed files.

## Review notes (non-blocking, pre-existing)
- The onboarding persistence contract (`hasCompletedOnboarding` / `otpServerURL` / `selectedRegion` keys + JSON-coded `OTPRegionInfo`) is still spelled out independently by the writer (`OnboardingViewController`) and the reader (now `SceneDelegate`). Consolidating it into a small shared store (and possibly dropping the derivable `hasCompletedOnboarding` flag) would be a good follow-up; left out here to keep the migration diff minimal.
- The demo scheme's test action is broken on `main` independent of this change: it references `OTPKitDemoTests/TestPlan.xctestplan`, which no longer exists (the demo test target was removed in an earlier reorganization).
- The old debug `print` statements in the launch path (including one that already claimed to be "SceneDelegate") were dropped rather than carried over.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/OneBusAway/codesmith/otpkit/pr/152"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787878071&installation_model_id=429412&pr_number=152&repository=OneBusAway%2Fotpkit&return_to=https%3A%2F%2Fgithub.com%2FOneBusAway%2Fotpkit%2Fpull%2F152&signature=cada1c90ec712998019c26050cb4eaa8594611248a6b61f6174fe6f1ecfd10a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->