### PR TITLE
Isolate OTPMapProvider to the main actor

### DIFF
--- a/OTPKit/Sources/OTPKit/Core/Map/OTPMapProvider.swift
+++ b/OTPKit/Sources/OTPKit/Core/Map/OTPMapProvider.swift
@@ -13,6 +13,13 @@ import SwiftUI
 /// Protocol defining the interface for map operations that OTPKit requires.
 /// Implementers of this protocol can provide their own map view (MKMapView, custom map, etc.)
 /// while allowing OTPKit to control map content and interactions.
+///
+/// Main-actor isolated because every call originates from `MapCoordinator`, which is
+/// itself `@MainActor`, and conformances drive UI. Stating that here rather than leaving
+/// it implicit lets hosts building in the Swift 6 language mode with main-actor default
+/// isolation conform directly, instead of opting the conformance out of isolation and
+/// hopping back in every method body.
+@MainActor
 public protocol OTPMapProvider: AnyObject {
 
     // MARK: - Route Display

--- a/OTPKit/Sources/OTPKit/Core/Map/OTPMapProvider.swift
+++ b/OTPKit/Sources/OTPKit/Core/Map/OTPMapProvider.swift
@@ -14,11 +14,14 @@ import SwiftUI
 /// Implementers of this protocol can provide their own map view (MKMapView, custom map, etc.)
 /// while allowing OTPKit to control map content and interactions.
 ///
-/// Main-actor isolated because every call originates from `MapCoordinator`, which is
-/// itself `@MainActor`, and conformances drive UI. Stating that here rather than leaving
-/// it implicit lets hosts building in the Swift 6 language mode with main-actor default
-/// isolation conform directly, instead of opting the conformance out of isolation and
-/// hopping back in every method body.
+/// Main-actor isolated because every call arrives from a main-actor context — from
+/// `MapCoordinator` inside the package, and from host UI code outside it — and because
+/// conformances drive UI. Conforming types inherit this isolation, so the members of a
+/// custom provider are main-actor isolated too.
+///
+/// Stating that here rather than leaving it implicit lets hosts building in the Swift 6
+/// language mode with main-actor default isolation conform directly, instead of opting
+/// the conformance out of isolation and hopping back in every method body.
 @MainActor
 public protocol OTPMapProvider: AnyObject {
 

--- a/OTPKit/Tests/SmokeTest.swift
+++ b/OTPKit/Tests/SmokeTest.swift
@@ -27,6 +27,9 @@ func testFixturesCreatePlace() {
     #expect(place.lon == -122.0)
 }
 
+// `MockMapProvider` conforms to `OTPMapProvider`, which is `@MainActor`, so the
+// mock picks up that isolation and the test has to run there too.
+@MainActor
 @Test("MockMapProvider - tracks addRoute calls")
 func mockMapProviderTracksRouteCalls() {
     let mockMap = MockMapProvider()

--- a/README.markdown
+++ b/README.markdown
@@ -112,7 +112,7 @@ Both are Swift actors conforming to `APIService`; you can also implement `APISer
 
 - **Transport modes:** pass `enabledTransportModes` to `OTPConfiguration` (defaults to transit, walk, bike, car). Rental modes like `.bikeRental` are opt-in and need an OTP 2.x server with rental data.
 - **Theme:** pass an `OTPThemeConfiguration` to adjust colors.
-- **Map behavior:** implement `OTPMapProvider` to control exactly how routes and stops render on your map.
+- **Map behavior:** implement `OTPMapProvider` to control exactly how routes and stops render on your map. The protocol is `@MainActor`, so conformances inherit main-actor isolation — write your provider as main-actor isolated rather than opting the conformance out.
 
 ### Localization
 


### PR DESCRIPTION
## Summary
- Annotates `OTPMapProvider` with `@MainActor`, documenting isolation that was already
  true in practice but unstated.
- Every call into the protocol already arrives from a main-actor context — `MapCoordinator`
  inside the package, host UI code outside it — and conformances drive UI: the shipped
  `MKMapViewAdapter` assigns an `MKMapView` delegate, installs a gesture recognizer and
  mutates overlays.
- Documents the requirement where host integrators will actually meet it: the protocol's
  own doc comment and the README's "Customizing" section.

## Why
Hosts that build in the Swift 6 language mode with main-actor default isolation cannot
conform to this protocol today. Their members come out `@MainActor` automatically, and a
main-actor-isolated method cannot satisfy a nonisolated protocol requirement, so the host
build fails outright.

The workaround available to a host — declaring the conformance `nonisolated` and wrapping
every body in `MainActor.assumeIsolated` — is boilerplate across all sixteen requirements
and asserts an invariant the package already guarantees. Stating the isolation here is
both more honest and less code.

This came out of work to render OTPKit trip plans on a SwiftUI `Map` in OneBusAway iOS,
which needs a second `OTPMapProvider` implementation backed by published state rather than
an `MKMapView`. That host builds in the Swift 6 language mode with the concurrency
diagnostic groups escalated to errors.

## Scope
Deliberately small. `MKMapViewAdapter` and the test `MockMapProvider` infer the isolation
through their conformances and needed no changes; only the mock's test required an
explicit `@MainActor`.

This is a source-breaking change for any host that conforms off the main actor, which is
why it is documented rather than slipped in — we are pre-1.0, and the README now tells
implementers what the protocol expects of them. Existing *callers* are unaffected: every
call site in this repo, the demo app included, is already main-actor isolated.

## Test plan
- [x] `xcodebuild build -scheme OTPKit` — BUILD SUCCEEDED, no new warnings
- [x] `xcodebuild test -scheme OTPKit` — 229 tests in 20 suites, TEST SUCCEEDED
- [x] `swiftlint --strict` — 0 violations in 143 files
- [x] Built OneBusAway iOS (`OBAKit`, Swift 6 language mode, main-actor default isolation,
      concurrency diagnostics as errors) against this branch via a local package path:
      BUILD SUCCEEDED, zero warnings in the five escalated concurrency groups
- [x] Full `OBAKitTests` run against this branch: 2277 tests, the only 2 failures
      reproduce identically on unmodified `main`

Note that this package builds with `swiftLanguageModes: [.v5]`, so CI here cannot exercise
the strict-isolation scenario this change exists to fix — the OneBusAway build above is the
only thing that does.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved map provider reliability by ensuring map-related operations are performed safely on the app’s main thread.
  * Updated map integrations and validation coverage to support the improved concurrency behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
